### PR TITLE
AB#277650 Add postpone() to in-app message interceptor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 6.5.0
 
 - Add `postpone()` to the In-App Message Interceptor API. When called, the message is not displayed and not marked as dismissed — it is moved to the back of the queue and will be re-intercepted on the next natural presentation trigger (e.g. app foreground, push tickle). Existing `show()` and `suppress()` behavior is unchanged.
+- Fix dismissed non-inbox in-app messages reappearing after app reopen due to race between local DB cleanup and backend sync. Dismissed rows are now kept for 1 hour before eviction.
 
 ## 6.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.5.0
+
+- Add `postpone()` to the In-App Message Interceptor API. When called, the message is not displayed and not marked as dismissed — it is moved to the back of the queue and will be re-intercepted on the next natural presentation trigger (e.g. app foreground, push tickle). Existing `show()` and `suppress()` behavior is unchanged.
+
 ## 6.4.1
 
 - Correct parsing of Embedded Messaging V2 endpoint response

--- a/OptimoveCore.podspec
+++ b/OptimoveCore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'OptimoveCore'
-  s.version          = '6.4.1'
+  s.version          = '6.5.0'
   s.summary          = 'Official Optimove SDK for iOS. Core framework.'
   s.description      = 'The core framework is used to share code-base between other Optimove frameworks.'
   s.homepage         = 'https://github.com/optimove-tech/Optimove-SDK-iOS'

--- a/OptimoveCore/Sources/Classes/Constants/SDKVersion.swift
+++ b/OptimoveCore/Sources/Classes/Constants/SDKVersion.swift
@@ -1,3 +1,3 @@
 //  Copyright © 2019 Optimove. All rights reserved.
 
-public let SDKVersion = "6.4.1"
+public let SDKVersion = "6.5.0"

--- a/OptimoveNotificationServiceExtension.podspec
+++ b/OptimoveNotificationServiceExtension.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'OptimoveNotificationServiceExtension'
-  s.version          = '6.4.1'
+  s.version          = '6.5.0'
   s.summary          = 'Official Optimove SDK for iOS. Notification service extension framework.'
   s.description      = 'The notification service extension is used for handling additional content in push notifications.'
   s.homepage         = 'https://github.com/optimove-tech/Optimove-SDK-iOS'

--- a/OptimoveSDK.podspec
+++ b/OptimoveSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'OptimoveSDK'
-  s.version          = '6.4.1'
+  s.version          = '6.5.0'
   s.summary          = 'Official Optimove SDK for iOS.'
   s.description      = 'The Optimove SDK framework is used for reporting events and receive push notifications.'
   s.homepage         = 'https://github.com/optimove-tech/Optimove-SDK-iOS'

--- a/OptimoveSDK/Sources/Classes/Optimobile/InApp/InAppManager.swift
+++ b/OptimoveSDK/Sources/Classes/Optimobile/InApp/InAppManager.swift
@@ -213,6 +213,8 @@ class InAppManager {
     }
 
     private func resetMessagingState() {
+        presenter.cancelCurrentPresentationQueue(waitForViewCleanup: true)
+
         guard let context = messagesContext else {
             NSLog("InAppManager: NSManagedObjectContext is nil in resetMessagingState")
             return

--- a/OptimoveSDK/Sources/Classes/Optimobile/InApp/InAppManager.swift
+++ b/OptimoveSDK/Sources/Classes/Optimobile/InApp/InAppManager.swift
@@ -455,12 +455,13 @@ class InAppManager {
 
         let messageExpiredCondition = "(expiresAt != nil AND expiresAt <= %@)"
 
-        let noInboxAndMessageDismissed = "(inboxConfig = nil AND dismissedAt != nil)"
+        let dismissGracePeriod = Date(timeIntervalSinceNow: -3600) as NSDate
+        let noInboxAndMessageDismissed = "(inboxConfig = nil AND dismissedAt != nil AND dismissedAt <= %@)"
         let noInboxAndMessageExpired = "(inboxConfig = nil AND " + messageExpiredCondition + ")"
         let inboxExpiredAndMessageDismissedOrExpired = "(inboxTo != nil AND inboxTo < %@ AND (dismissedAt != nil OR " + messageExpiredCondition + "))"
 
         let predicate: NSPredicate? =
-            NSPredicate(format: noInboxAndMessageDismissed + " OR " + noInboxAndMessageExpired + " OR " + inboxExpiredAndMessageDismissedOrExpired, NSDate(), NSDate(), NSDate())
+            NSPredicate(format: noInboxAndMessageDismissed + " OR " + noInboxAndMessageExpired + " OR " + inboxExpiredAndMessageDismissedOrExpired, dismissGracePeriod, NSDate(), NSDate(), NSDate())
         fetchRequest.predicate = predicate
 
         var toEvict: [InAppMessageEntity]

--- a/OptimoveSDK/Sources/Classes/Optimobile/InApp/InAppPresenter.swift
+++ b/OptimoveSDK/Sources/Classes/Optimobile/InApp/InAppPresenter.swift
@@ -221,6 +221,7 @@ final class InAppPresenter: NSObject, WKScriptMessageHandler, WKNavigationDelega
         messageQueue.removeAllObjects()
         pendingTickleIds.removeAllObjects()
         currentMessage = nil
+        interceptionInProgress = false
 
         if waitForViewCleanup == true {
             self.destroyViews()

--- a/OptimoveSDK/Sources/Classes/Optimobile/InApp/InAppPresenter.swift
+++ b/OptimoveSDK/Sources/Classes/Optimobile/InApp/InAppPresenter.swift
@@ -37,11 +37,13 @@ final class InAppPresenter: NSObject, WKScriptMessageHandler, WKNavigationDelega
         private var resolved: Bool = false
         private let onShow: () -> Void
         private let onSuppress: () -> Void
+        private let onPostpone: () -> Void
         private var cancelTimeout: (() -> Void)?
 
-        init(onShow: @escaping () -> Void, onSuppress: @escaping () -> Void) {
+        init(onShow: @escaping () -> Void, onSuppress: @escaping () -> Void, onPostpone: @escaping () -> Void) {
             self.onShow = onShow
             self.onSuppress = onSuppress
+            self.onPostpone = onPostpone
         }
 
         func setCancelTimeout(_ cancel: @escaping () -> Void) {
@@ -63,6 +65,15 @@ final class InAppPresenter: NSObject, WKScriptMessageHandler, WKNavigationDelega
                 self.resolved = true
                 self.cancelTimeout?()
                 self.onSuppress()
+            }
+        }
+
+        func postpone() {
+            DispatchQueue.main.async {
+                guard !self.resolved else { return }
+                self.resolved = true
+                self.cancelTimeout?()
+                self.onPostpone()
             }
         }
     }
@@ -483,6 +494,9 @@ final class InAppPresenter: NSObject, WKScriptMessageHandler, WKNavigationDelega
             },
             onSuppress: { [weak self] in
                 self?.handleSuppressDecision(for: message)
+            },
+            onPostpone: { [weak self] in
+                self?.handlePostponeDecision(for: message)
             }
         )
 
@@ -520,6 +534,23 @@ final class InAppPresenter: NSObject, WKScriptMessageHandler, WKNavigationDelega
         if webViewReady {
             showMessage(message)
         }
+    }
+
+    private func handlePostponeDecision(for message: InAppMessage) {
+        assertOnMainThread()
+
+        interceptionInProgress = false
+
+        destroyViews()
+
+        let idx = messageQueue.index(of: message)
+        if idx != NSNotFound {
+            messageQueue.removeObject(at: idx)
+            messageQueue.add(message)
+        }
+
+        pendingTickleIds.remove(message.id)
+        currentMessage = nil
     }
 
     private func handleSuppressDecision(for message: InAppMessage) {

--- a/OptimoveSDK/Sources/Classes/Optimobile/OptimoveInApp.swift
+++ b/OptimoveSDK/Sources/Classes/Optimobile/OptimoveInApp.swift
@@ -204,7 +204,6 @@ public enum OptimoveInApp {
 // MARK: - Interceptor Protocols
 
 public protocol InAppMessageInterceptor {
-    // Async decision, call either decision.show() or decision.suppress()
     func processMessage(data: [String: Any]?, decision: InAppMessageInterceptorDecision)
 
     func getTimeoutMs() -> Int
@@ -213,6 +212,7 @@ public protocol InAppMessageInterceptor {
 public protocol InAppMessageInterceptorDecision {
     func show()
     func suppress()
+    func postpone()
 }
 
 public extension InAppMessageInterceptor {


### PR DESCRIPTION
### Description of Changes

 Extends the in-app message interception with a third outcome - postpone() - that moves the message to the back of the queue without showing or dismissing it. The message is re-intercepted on the next natural presentation trigger

### Breaking Changes

-   None

### Release Checklist

### Prepare:

- [ ] Detail any breaking changes. Breaking changes require a new major version number
- [ ] Check `pod lib lint` passes
- [ ] Update any relevant sections of the repository wiki pages on a branch

### Bump versions in:

- [x] `OptimoveCore.podspec`
- [x] `OptimoveNotificationServiceExtension.podspec`
- [x] `OptimoveSDK.podspec`

- [x] `OptimoveCore/Sources/Classes/Constants/SDKVersion.swift`

- [ ] `README.md`
- [ ] `CHANGELOG.md`

- [ ] Update major version numbers in wiki (basic integration + push guides)

### Integration tests

*T&T Only*

- [ ] Init SDK with only T&T credentials
- [ ] Associate customer
- [ ] Associate email
- [ ] Track events

*Mobile Only*

- [ ] Init SDK with all credentials
- [ ] Track events
- [ ] Associate customer (verify both backends)
- [ ] Register for push
- [ ] Opt-in for In-App
- [ ] Send test push
- [ ] Send test In-App
- [ ] Receive / trigger deep link handler (In-App/Push)
- [ ] Receive / trigger the content extension, render image and action buttons for push
- [ ] Verify push opened handler

*Deferred Deep Links*

- [ ] With app installed, trigger deep link handler
- [ ] With app uninstalled, follow deep link, install test bundle, verify deep link read from Clipboard, trigger deep link handler

*Combined*

- [ ] Track event for T&T, verify push received
- [ ] Trigger scheduled campaign, verify push received
- [ ] Trigger scheduled campaign, verify In-App received

### Release:

- [ ] Squash and merge to master
- [ ] Delete branch once merged
- [ ] Create tag from master matching chosen version
- [ ] Run `pod trunk push` to publish to CocoaPods

### Post Release:

- [ ] Push wiki pages to master

