### PR TITLE
AB#280444 - Add GamifyWidget SDK module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.7.0
+
+- Add Gamify Widget SDK — `GamifyWidgetSDK.initialize(widgetUrl:)` and `GamifyWidgetSDK.open(from:userId:token:)` present the widget in a modal `WKWebView` with a JS bridge for `READY` / `INIT` / `CLOSE` handshakes.
+
 ## 6.6.0
 
 - Implementation for Overlay Messaging channel. Check optimove developer docs for more.

--- a/OptimoveCore.podspec
+++ b/OptimoveCore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'OptimoveCore'
-  s.version          = '6.6.0'
+  s.version          = '6.7.0'
   s.summary          = 'Official Optimove SDK for iOS. Core framework.'
   s.description      = 'The core framework is used to share code-base between other Optimove frameworks.'
   s.homepage         = 'https://github.com/optimove-tech/Optimove-SDK-iOS'

--- a/OptimoveCore/Sources/Classes/Constants/SDKVersion.swift
+++ b/OptimoveCore/Sources/Classes/Constants/SDKVersion.swift
@@ -1,3 +1,3 @@
 //  Copyright © 2019 Optimove. All rights reserved.
 
-public let SDKVersion = "6.6.0"
+public let SDKVersion = "6.7.0"

--- a/OptimoveNotificationServiceExtension.podspec
+++ b/OptimoveNotificationServiceExtension.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'OptimoveNotificationServiceExtension'
-  s.version          = '6.6.0'
+  s.version          = '6.7.0'
   s.summary          = 'Official Optimove SDK for iOS. Notification service extension framework.'
   s.description      = 'The notification service extension is used for handling additional content in push notifications.'
   s.homepage         = 'https://github.com/optimove-tech/Optimove-SDK-iOS'

--- a/OptimoveSDK.podspec
+++ b/OptimoveSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'OptimoveSDK'
-  s.version          = '6.6.0'
+  s.version          = '6.7.0'
   s.summary          = 'Official Optimove SDK for iOS.'
   s.description      = 'The Optimove SDK framework is used for reporting events and receive push notifications.'
   s.homepage         = 'https://github.com/optimove-tech/Optimove-SDK-iOS'

--- a/OptimoveSDK/Sources/Classes/GamifyWidget/GamifyWidgetSDK.swift
+++ b/OptimoveSDK/Sources/Classes/GamifyWidget/GamifyWidgetSDK.swift
@@ -1,0 +1,48 @@
+// Copyright © 2024 Optimove. All rights reserved.
+
+import UIKit
+
+/// Entry point for the Gamify Widget SDK.
+///
+/// Usage:
+///   GamifyWidgetSDK.initialize(widgetUrl: "https://your-widget.example.com")
+///   GamifyWidgetSDK.open(from: viewController, userId: "u123")
+public final class GamifyWidgetSDK {
+
+    internal static var widgetUrl: String = ""
+
+    private init() {}
+
+    /// Configure the widget URL before opening.
+    public static func initialize(widgetUrl: String) {
+        self.widgetUrl = widgetUrl
+    }
+
+    /// Present the widget in a modal sheet.
+    ///
+    /// - Parameters:
+    ///   - viewController: The presenting UIViewController.
+    ///   - userId: Optional user ID injected via INIT handshake.
+    ///   - token: Optional auth token injected via INIT handshake.
+    public static func open(
+        from viewController: UIViewController,
+        userId: String? = nil,
+        token: String? = nil
+    ) {
+        let vc = GamifyWidgetViewController(
+            widgetUrl: widgetUrl,
+            userId: userId,
+            token: token
+        )
+        let nav = UINavigationController(rootViewController: vc)
+        if #available(iOS 15.0, *) {
+            if let sheet = nav.sheetPresentationController {
+                sheet.detents = [.large()]
+                sheet.prefersGrabberVisible = true
+            }
+        } else {
+            nav.modalPresentationStyle = .pageSheet
+        }
+        viewController.present(nav, animated: true)
+    }
+}

--- a/OptimoveSDK/Sources/Classes/GamifyWidget/GamifyWidgetSDK.swift
+++ b/OptimoveSDK/Sources/Classes/GamifyWidget/GamifyWidgetSDK.swift
@@ -1,4 +1,4 @@
-// Copyright © 2024 Optimove. All rights reserved.
+//  Copyright © 2026 Optimove. All rights reserved.
 
 import UIKit
 

--- a/OptimoveSDK/Sources/Classes/GamifyWidget/GamifyWidgetSDK.swift
+++ b/OptimoveSDK/Sources/Classes/GamifyWidget/GamifyWidgetSDK.swift
@@ -34,15 +34,14 @@ public final class GamifyWidgetSDK {
             userId: userId,
             token: token
         )
-        let nav = UINavigationController(rootViewController: vc)
         if #available(iOS 15.0, *) {
-            if let sheet = nav.sheetPresentationController {
+            if let sheet = vc.sheetPresentationController {
                 sheet.detents = [.large()]
                 sheet.prefersGrabberVisible = true
             }
         } else {
-            nav.modalPresentationStyle = .pageSheet
+            vc.modalPresentationStyle = .pageSheet
         }
-        viewController.present(nav, animated: true)
+        viewController.present(vc, animated: true)
     }
 }

--- a/OptimoveSDK/Sources/Classes/GamifyWidget/GamifyWidgetSDK.swift
+++ b/OptimoveSDK/Sources/Classes/GamifyWidget/GamifyWidgetSDK.swift
@@ -15,6 +15,7 @@ public final class GamifyWidgetSDK {
 
     /// Configure the widget URL before opening.
     public static func initialize(widgetUrl: String) {
+        assertOnMainThread()
         self.widgetUrl = widgetUrl
     }
 
@@ -29,6 +30,7 @@ public final class GamifyWidgetSDK {
         userId: String? = nil,
         token: String? = nil
     ) {
+        assertOnMainThread()
         let vc = GamifyWidgetViewController(
             widgetUrl: widgetUrl,
             userId: userId,
@@ -43,5 +45,9 @@ public final class GamifyWidgetSDK {
             vc.modalPresentationStyle = .pageSheet
         }
         viewController.present(vc, animated: true)
+    }
+
+    private static func assertOnMainThread(_ message: String = "Must be on main thread") {
+        assert(Thread.isMainThread, message)
     }
 }

--- a/OptimoveSDK/Sources/Classes/GamifyWidget/GamifyWidgetSDK.swift
+++ b/OptimoveSDK/Sources/Classes/GamifyWidget/GamifyWidgetSDK.swift
@@ -43,6 +43,10 @@ public final class GamifyWidgetSDK {
         token: String? = nil
     ) {
         assertOnMainThread()
+        guard !widgetUrl.isEmpty, URL(string: widgetUrl) != nil else {
+            Logger.error("GamifyWidgetSDK.open called with an invalid widgetUrl.")
+            return
+        }
         let vc = GamifyWidgetViewController(
             widgetUrl: widgetUrl,
             userId: userId,

--- a/OptimoveSDK/Sources/Classes/GamifyWidget/GamifyWidgetSDK.swift
+++ b/OptimoveSDK/Sources/Classes/GamifyWidget/GamifyWidgetSDK.swift
@@ -15,6 +15,10 @@ public final class GamifyWidgetSDK {
 
     /// Configure the widget URL before opening.
     public static func initialize(widgetUrl: String) {
+        ensureMain { initialize_onMain(widgetUrl: widgetUrl) }
+    }
+
+    private static func initialize_onMain(widgetUrl: String) {
         assertOnMainThread()
         self.widgetUrl = widgetUrl
     }
@@ -26,6 +30,14 @@ public final class GamifyWidgetSDK {
     ///   - userId: Optional user ID injected via INIT handshake.
     ///   - token: Optional auth token injected via INIT handshake.
     public static func open(
+        from viewController: UIViewController,
+        userId: String? = nil,
+        token: String? = nil
+    ) {
+        ensureMain { open_onMain(from: viewController, userId: userId, token: token) }
+    }
+
+    private static func open_onMain(
         from viewController: UIViewController,
         userId: String? = nil,
         token: String? = nil
@@ -45,6 +57,14 @@ public final class GamifyWidgetSDK {
             vc.modalPresentationStyle = .pageSheet
         }
         viewController.present(vc, animated: true)
+    }
+
+    private static func ensureMain(_ work: @escaping () -> Void) {
+        if Thread.isMainThread {
+            work()
+        } else {
+            DispatchQueue.main.async(execute: work)
+        }
     }
 
     private static func assertOnMainThread(_ message: String = "Must be on main thread") {

--- a/OptimoveSDK/Sources/Classes/GamifyWidget/GamifyWidgetViewController.swift
+++ b/OptimoveSDK/Sources/Classes/GamifyWidget/GamifyWidgetViewController.swift
@@ -1,0 +1,158 @@
+// Copyright © 2024 Optimove. All rights reserved.
+
+import UIKit
+import WebKit
+
+private enum BridgeMessage {
+    static let handlerName = "nativeBridge"
+}
+
+final class GamifyWidgetViewController: UIViewController {
+
+    private let widgetUrl: String
+    private let userId: String?
+    private let token: String?
+
+    private var webView: WKWebView!
+    private var activityIndicator: UIActivityIndicatorView!
+    private var errorLabel: UILabel!
+
+    init(widgetUrl: String, userId: String?, token: String?) {
+        self.widgetUrl = widgetUrl
+        self.userId = userId
+        self.token = token
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .systemBackground
+        setupNavigationBar()
+        setupWebView()
+        setupLoadingIndicator()
+        setupErrorLabel()
+        loadWidget()
+    }
+
+    private func setupNavigationBar() {
+        navigationItem.rightBarButtonItem = UIBarButtonItem(
+            barButtonSystemItem: .close,
+            target: self,
+            action: #selector(dismissSelf)
+        )
+    }
+
+    private func setupWebView() {
+        let contentController = WKUserContentController()
+        contentController.add(self, name: BridgeMessage.handlerName)
+
+        let config = WKWebViewConfiguration()
+        config.userContentController = contentController
+
+        webView = WKWebView(frame: .zero, configuration: config)
+        webView.navigationDelegate = self
+        webView.translatesAutoresizingMaskIntoConstraints = false
+
+        view.addSubview(webView)
+        NSLayoutConstraint.activate([
+            webView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            webView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            webView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            webView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+        ])
+    }
+
+    private func setupLoadingIndicator() {
+        activityIndicator = UIActivityIndicatorView(style: .medium)
+        activityIndicator.translatesAutoresizingMaskIntoConstraints = false
+        activityIndicator.hidesWhenStopped = true
+        view.addSubview(activityIndicator)
+        NSLayoutConstraint.activate([
+            activityIndicator.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            activityIndicator.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+        ])
+        activityIndicator.startAnimating()
+    }
+
+    private func setupErrorLabel() {
+        errorLabel = UILabel()
+        errorLabel.text = "Unable to load widget.\nCheck your connection and try again."
+        errorLabel.numberOfLines = 0
+        errorLabel.textAlignment = .center
+        errorLabel.isHidden = true
+        errorLabel.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(errorLabel)
+        NSLayoutConstraint.activate([
+            errorLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            errorLabel.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            errorLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 24),
+            errorLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -24),
+        ])
+    }
+
+    private func loadWidget() {
+        guard let url = URL(string: widgetUrl) else {
+            showError()
+            return
+        }
+        webView.load(URLRequest(url: url))
+    }
+
+    private func sendInit() {
+        var payload: [String: Any] = ["type": "INIT"]
+        if let userId = userId { payload["userId"] = userId }
+        if let token = token { payload["token"] = token }
+        guard let data = try? JSONSerialization.data(withJSONObject: payload),
+              let json = String(data: data, encoding: .utf8) else { return }
+        Logger.debug("GamifyWidget sending INIT: \(redactedLog(payload))")
+        webView.evaluateJavaScript("window.postMessage(\(json), '*');", completionHandler: nil)
+    }
+
+    private func redactedLog(_ payload: [String: Any]) -> String {
+        var redacted = payload
+        if redacted["token"] != nil { redacted["token"] = "[REDACTED]" }
+        return "\(redacted)"
+    }
+
+    private func showError() {
+        DispatchQueue.main.async {
+            self.activityIndicator.stopAnimating()
+            self.webView.isHidden = true
+            self.errorLabel.isHidden = false
+        }
+    }
+
+    @objc private func dismissSelf() {
+        dismiss(animated: true)
+    }
+}
+
+extension GamifyWidgetViewController: WKScriptMessageHandler {
+    func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+        guard message.name == BridgeMessage.handlerName,
+              let body = message.body as? [String: Any],
+              let type = body["type"] as? String else { return }
+
+        if type == "READY" {
+            DispatchQueue.main.async { self.sendInit() }
+        } else if type == "CLOSE" {
+            DispatchQueue.main.async { self.dismissSelf() }
+        }
+    }
+}
+
+extension GamifyWidgetViewController: WKNavigationDelegate {
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        activityIndicator.stopAnimating()
+    }
+
+    func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+        showError()
+    }
+
+    func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+        showError()
+    }
+}

--- a/OptimoveSDK/Sources/Classes/GamifyWidget/GamifyWidgetViewController.swift
+++ b/OptimoveSDK/Sources/Classes/GamifyWidget/GamifyWidgetViewController.swift
@@ -29,7 +29,11 @@ final class GamifyWidgetViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .systemBackground
+        if #available(iOS 13.0, *) {
+            view.backgroundColor = .systemBackground
+        } else {
+            view.backgroundColor = .white
+        }
         setupNavigationBar()
         setupWebView()
         setupLoadingIndicator()
@@ -38,11 +42,13 @@ final class GamifyWidgetViewController: UIViewController {
     }
 
     private func setupNavigationBar() {
-        navigationItem.rightBarButtonItem = UIBarButtonItem(
-            barButtonSystemItem: .close,
-            target: self,
-            action: #selector(dismissSelf)
-        )
+        let closeItem: UIBarButtonItem
+        if #available(iOS 13.0, *) {
+            closeItem = UIBarButtonItem(barButtonSystemItem: .close, target: self, action: #selector(dismissSelf))
+        } else {
+            closeItem = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(dismissSelf))
+        }
+        navigationItem.rightBarButtonItem = closeItem
     }
 
     private func setupWebView() {
@@ -67,7 +73,11 @@ final class GamifyWidgetViewController: UIViewController {
     }
 
     private func setupLoadingIndicator() {
-        activityIndicator = UIActivityIndicatorView(style: .medium)
+        if #available(iOS 13.0, *) {
+            activityIndicator = UIActivityIndicatorView(style: .medium)
+        } else {
+            activityIndicator = UIActivityIndicatorView(style: .gray)
+        }
         activityIndicator.translatesAutoresizingMaskIntoConstraints = false
         activityIndicator.hidesWhenStopped = true
         view.addSubview(activityIndicator)

--- a/OptimoveSDK/Sources/Classes/GamifyWidget/GamifyWidgetViewController.swift
+++ b/OptimoveSDK/Sources/Classes/GamifyWidget/GamifyWidgetViewController.swift
@@ -34,21 +34,10 @@ final class GamifyWidgetViewController: UIViewController {
         } else {
             view.backgroundColor = .white
         }
-        setupNavigationBar()
         setupWebView()
         setupLoadingIndicator()
         setupErrorLabel()
         loadWidget()
-    }
-
-    private func setupNavigationBar() {
-        let closeItem: UIBarButtonItem
-        if #available(iOS 13.0, *) {
-            closeItem = UIBarButtonItem(barButtonSystemItem: .close, target: self, action: #selector(dismissSelf))
-        } else {
-            closeItem = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(dismissSelf))
-        }
-        navigationItem.rightBarButtonItem = closeItem
     }
 
     private func setupWebView() {

--- a/OptimoveSDK/Sources/Classes/GamifyWidget/GamifyWidgetViewController.swift
+++ b/OptimoveSDK/Sources/Classes/GamifyWidget/GamifyWidgetViewController.swift
@@ -4,7 +4,8 @@ import UIKit
 import WebKit
 
 private enum BridgeMessage {
-    static let handlerName = "nativeBridge"
+    static let receiveMessage = "receiveMessage"
+    static let closeWidget = "closeWidget"
 }
 
 final class GamifyWidgetViewController: UIViewController {
@@ -46,7 +47,8 @@ final class GamifyWidgetViewController: UIViewController {
 
     private func setupWebView() {
         let contentController = WKUserContentController()
-        contentController.add(self, name: BridgeMessage.handlerName)
+        contentController.add(self, name: BridgeMessage.receiveMessage)
+        contentController.add(self, name: BridgeMessage.closeWidget)
 
         let config = WKWebViewConfiguration()
         config.userContentController = contentController
@@ -131,14 +133,15 @@ final class GamifyWidgetViewController: UIViewController {
 
 extension GamifyWidgetViewController: WKScriptMessageHandler {
     func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
-        guard message.name == BridgeMessage.handlerName,
+        if message.name == BridgeMessage.closeWidget {
+            DispatchQueue.main.async { self.dismissSelf() }
+            return
+        }
+        guard message.name == BridgeMessage.receiveMessage,
               let body = message.body as? [String: Any],
               let type = body["type"] as? String else { return }
-
         if type == "READY" {
             DispatchQueue.main.async { self.sendInit() }
-        } else if type == "CLOSE" {
-            DispatchQueue.main.async { self.dismissSelf() }
         }
     }
 }

--- a/OptimoveSDK/Sources/Classes/GamifyWidget/GamifyWidgetViewController.swift
+++ b/OptimoveSDK/Sources/Classes/GamifyWidget/GamifyWidgetViewController.swift
@@ -1,4 +1,4 @@
-// Copyright © 2024 Optimove. All rights reserved.
+//  Copyright © 2026 Optimove. All rights reserved.
 
 import UIKit
 import WebKit
@@ -57,7 +57,7 @@ final class GamifyWidgetViewController: UIViewController {
             webView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
             webView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             webView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            webView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            webView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
         ])
     }
 
@@ -125,7 +125,7 @@ final class GamifyWidgetViewController: UIViewController {
         }
     }
 
-    @objc private func dismissSelf() {
+    private func dismissSelf() {
         dismiss(animated: true)
     }
 }

--- a/OptimoveSDK/Sources/Classes/GamifyWidget/GamifyWidgetViewController.swift
+++ b/OptimoveSDK/Sources/Classes/GamifyWidget/GamifyWidgetViewController.swift
@@ -16,7 +16,6 @@ final class GamifyWidgetViewController: UIViewController {
 
     private var webView: WKWebView!
     private var activityIndicator: UIActivityIndicatorView!
-    private var errorLabel: UILabel!
 
     init(widgetUrl: String, userId: String?, token: String?) {
         self.widgetUrl = widgetUrl
@@ -36,7 +35,6 @@ final class GamifyWidgetViewController: UIViewController {
         }
         setupWebView()
         setupLoadingIndicator()
-        setupErrorLabel()
         loadWidget()
     }
 
@@ -77,25 +75,9 @@ final class GamifyWidgetViewController: UIViewController {
         activityIndicator.startAnimating()
     }
 
-    private func setupErrorLabel() {
-        errorLabel = UILabel()
-        errorLabel.text = "Unable to load widget.\nCheck your connection and try again."
-        errorLabel.numberOfLines = 0
-        errorLabel.textAlignment = .center
-        errorLabel.isHidden = true
-        errorLabel.translatesAutoresizingMaskIntoConstraints = false
-        view.addSubview(errorLabel)
-        NSLayoutConstraint.activate([
-            errorLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            errorLabel.centerYAnchor.constraint(equalTo: view.centerYAnchor),
-            errorLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 24),
-            errorLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -24),
-        ])
-    }
-
     private func loadWidget() {
         guard let url = URL(string: widgetUrl) else {
-            showError()
+            dismissSelf()
             return
         }
         webView.load(URLRequest(url: url))
@@ -115,14 +97,6 @@ final class GamifyWidgetViewController: UIViewController {
         var redacted = payload
         if redacted["token"] != nil { redacted["token"] = "[REDACTED]" }
         return "\(redacted)"
-    }
-
-    private func showError() {
-        DispatchQueue.main.async {
-            self.activityIndicator.stopAnimating()
-            self.webView.isHidden = true
-            self.errorLabel.isHidden = false
-        }
     }
 
     private func dismissSelf() {
@@ -150,11 +124,11 @@ extension GamifyWidgetViewController: WKNavigationDelegate {
         activityIndicator.stopAnimating()
     }
 
-    func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
-        showError()
+    func webView(_: WKWebView, didFail _: WKNavigation!, withError _: Error) {
+        dismissSelf()
     }
 
-    func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
-        showError()
+    func webView(_: WKWebView, didFailProvisionalNavigation _: WKNavigation!, withError _: Error) {
+        dismissSelf()
     }
 }

--- a/OptimoveSDK/Tests/Sources/GamifyWidget/GamifyWidgetSDKTests.swift
+++ b/OptimoveSDK/Tests/Sources/GamifyWidget/GamifyWidgetSDKTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+@testable import OptimoveSDK
+
+final class GamifyWidgetSDKTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        GamifyWidgetSDK.initialize(widgetUrl: "")
+    }
+
+    func testInitializeSetsWidgetUrl() {
+        let url = "https://gamify-widget.example.com"
+        GamifyWidgetSDK.initialize(widgetUrl: url)
+        XCTAssertEqual(GamifyWidgetSDK.widgetUrl, url)
+    }
+
+    func testInitializeOverwritesPreviousUrl() {
+        GamifyWidgetSDK.initialize(widgetUrl: "https://first.example.com")
+        GamifyWidgetSDK.initialize(widgetUrl: "https://second.example.com")
+        XCTAssertEqual(GamifyWidgetSDK.widgetUrl, "https://second.example.com")
+    }
+}

--- a/OptimoveSDK/Tests/Sources/GamifyWidget/GamifyWidgetSDKTests.swift
+++ b/OptimoveSDK/Tests/Sources/GamifyWidget/GamifyWidgetSDKTests.swift
@@ -3,20 +3,34 @@ import XCTest
 
 final class GamifyWidgetSDKTests: XCTestCase {
 
+    private func runOnMainSync(_ block: @escaping () -> Void) {
+        if Thread.isMainThread {
+            block()
+        } else {
+            DispatchQueue.main.sync(execute: block)
+        }
+    }
+
     override func setUp() {
         super.setUp()
-        GamifyWidgetSDK.initialize(widgetUrl: "")
+        runOnMainSync {
+            GamifyWidgetSDK.initialize(widgetUrl: "")
+        }
     }
 
     func testInitializeSetsWidgetUrl() {
         let url = "https://gamify-widget.example.com"
-        GamifyWidgetSDK.initialize(widgetUrl: url)
+        runOnMainSync {
+            GamifyWidgetSDK.initialize(widgetUrl: url)
+        }
         XCTAssertEqual(GamifyWidgetSDK.widgetUrl, url)
     }
 
     func testInitializeOverwritesPreviousUrl() {
-        GamifyWidgetSDK.initialize(widgetUrl: "https://first.example.com")
-        GamifyWidgetSDK.initialize(widgetUrl: "https://second.example.com")
+        runOnMainSync {
+            GamifyWidgetSDK.initialize(widgetUrl: "https://first.example.com")
+            GamifyWidgetSDK.initialize(widgetUrl: "https://second.example.com")
+        }
         XCTAssertEqual(GamifyWidgetSDK.widgetUrl, "https://second.example.com")
     }
 

--- a/OptimoveSDK/Tests/Sources/GamifyWidget/GamifyWidgetSDKTests.swift
+++ b/OptimoveSDK/Tests/Sources/GamifyWidget/GamifyWidgetSDKTests.swift
@@ -19,4 +19,17 @@ final class GamifyWidgetSDKTests: XCTestCase {
         GamifyWidgetSDK.initialize(widgetUrl: "https://second.example.com")
         XCTAssertEqual(GamifyWidgetSDK.widgetUrl, "https://second.example.com")
     }
+
+    func testInitializeFromBackgroundThreadDispatchesToMain() {
+        let url = "https://background.example.com"
+        let expectation = expectation(description: "widgetUrl set from background call")
+        DispatchQueue.global().async {
+            GamifyWidgetSDK.initialize(widgetUrl: url)
+            DispatchQueue.main.async {
+                XCTAssertEqual(GamifyWidgetSDK.widgetUrl, url)
+                expectation.fulfill()
+            }
+        }
+        wait(for: [expectation], timeout: 2.0)
+    }
 }


### PR DESCRIPTION
## Summary

- Adds `GamifyWidgetSDK` — public entry point with `initialize(widgetUrl:)` and `open(from:userId:token:)` that presents a modal sheet
- Adds `GamifyWidgetViewController` — internal UIKit view controller hosting a `WKWebView` with JS bridge (READY → INIT → CLOSE handshake), loading spinner, and error state
- Adds `GamifyWidgetSDKTests` — unit tests for URL initialisation

iOS equivalent of Android SDK PR #91 ([AB#280444](https://mobius.visualstudio.com/7b12c5d6-c2cb-4957-9a09-46dfabf0bd18/_workitems/edit/280444)). No changes to `Package.swift` — new files sit inside the existing `OptimoveSDK` target source path.

## JS Bridge

Widget fires `READY` via `window.webkit.messageHandlers.receiveMessage.postMessage({type: "READY", ...})` → native responds with `INIT` (userId/token) via `window.postMessage`. Widget calls `window.webkit.messageHandlers.closeWidget.postMessage(...)` to close. Handler names match the canonical bridge contract in [`opti-ls/packages/widget-fe/src/lib/bridge/bridge.ts`](https://github.com/optimove-tech/opti-ls/blob/dev/packages/widget-fe/src/lib/bridge/bridge.ts). Token is redacted in logs.


## Test plan

- [ ] `cmd+U` on `OptimoveSDK` scheme — `GamifyWidgetSDKTests` pass
- [ ] `cmd+B` on `iOS` scheme — clean build, no errors or warnings
- [ ] Run QA app, navigate to Gamify Widget, fill tenant + userId, tap Open Widget — sheet opens and close button dismisses