### PR TITLE
AB#289456 Update session length handling in Overlay Messaging 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 6.9.0
 
 - Add `OptimoveConfigBuilder.enableOverlayMessaging(sessionLengthMinutes:)` overload to configure the overlay messaging session window in minutes (minimum 15). The existing `enableOverlayMessaging(sessionLengthHours:)` overload is unchanged.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Lower the minimum `sessionLengthHours` for `OptimoveConfigBuilder.enableOverlayMessaging(sessionLengthHours:)` from 1 hour to 0.25 hours (15 minutes), and change its type from `Int` to `Double` to support fractional-hour values.
+
 ## 6.8.0
 
 - Add `OptimoveOverlayMessaging.setActionHandler(_:)` — register a handler to intercept overlay CTA clicks and perform custom navigation instead of the SDK opening the URL.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Lower the minimum `sessionLengthHours` for `OptimoveConfigBuilder.enableOverlayMessaging(sessionLengthHours:)` from 1 hour to 0.25 hours (15 minutes), and change its type from `Int` to `Double` to support fractional-hour values.
+- Add `OptimoveConfigBuilder.enableOverlayMessaging(sessionLengthMinutes:)` overload to configure the overlay messaging session window in minutes (minimum 15). The existing `enableOverlayMessaging(sessionLengthHours:)` overload is unchanged.
 
 ## 6.8.0
 

--- a/OptimoveCore.podspec
+++ b/OptimoveCore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'OptimoveCore'
-  s.version          = '6.8.0'
+  s.version          = '6.9.0'
   s.summary          = 'Official Optimove SDK for iOS. Core framework.'
   s.description      = 'The core framework is used to share code-base between other Optimove frameworks.'
   s.homepage         = 'https://github.com/optimove-tech/Optimove-SDK-iOS'

--- a/OptimoveCore/Sources/Classes/Constants/SDKVersion.swift
+++ b/OptimoveCore/Sources/Classes/Constants/SDKVersion.swift
@@ -1,3 +1,3 @@
 //  Copyright © 2019 Optimove. All rights reserved.
 
-public let SDKVersion = "6.8.0"
+public let SDKVersion = "6.9.0"

--- a/OptimoveNotificationServiceExtension.podspec
+++ b/OptimoveNotificationServiceExtension.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'OptimoveNotificationServiceExtension'
-  s.version          = '6.8.0'
+  s.version          = '6.9.0'
   s.summary          = 'Official Optimove SDK for iOS. Notification service extension framework.'
   s.description      = 'The notification service extension is used for handling additional content in push notifications.'
   s.homepage         = 'https://github.com/optimove-tech/Optimove-SDK-iOS'

--- a/OptimoveSDK.podspec
+++ b/OptimoveSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'OptimoveSDK'
-  s.version          = '6.8.0'
+  s.version          = '6.9.0'
   s.summary          = 'Official Optimove SDK for iOS.'
   s.description      = 'The Optimove SDK framework is used for reporting events and receive push notifications.'
   s.homepage         = 'https://github.com/optimove-tech/Optimove-SDK-iOS'

--- a/OptimoveSDK/Sources/Classes/Optimobile/Optimobile+Analytics.swift
+++ b/OptimoveSDK/Sources/Classes/Optimobile/Optimobile+Analytics.swift
@@ -105,6 +105,10 @@ extension Optimobile {
 
         if currentUserId == nil || currentUserId != userIdentifier {
             getInstance().inAppManager.handleAssociatedUserChange()
+
+            if Optimobile.sharedInstance.config.isOverlayMessagingEnabled {
+                OptimoveOverlayMessaging.resetSession()
+            }
         }
     }
 }

--- a/OptimoveSDK/Sources/Classes/Optimobile/OverlayMessaging/OptimoveOverlayMessaging.swift
+++ b/OptimoveSDK/Sources/Classes/Optimobile/OverlayMessaging/OptimoveOverlayMessaging.swift
@@ -8,10 +8,10 @@ public class OptimoveOverlayMessaging {
     
     private let manager: OverlayMessagingManager
     private var sessionManager: OverlayMessagingSessionManager?
-    private let sessionLengthHours: Int
+    private let sessionLengthHours: Double
     private var initializationToken: NSObjectProtocol?
-    
-    private init(sessionLengthHours: Int, httpClient: KSHttpClient, urlBuilder: UrlBuilder) {
+
+    private init(sessionLengthHours: Double, httpClient: KSHttpClient, urlBuilder: UrlBuilder) {
         self.sessionLengthHours = sessionLengthHours
         self.manager = OverlayMessagingManager(httpClient: httpClient, urlBuilder: urlBuilder)
     }

--- a/OptimoveSDK/Sources/Classes/Optimobile/OverlayMessaging/OptimoveOverlayMessaging.swift
+++ b/OptimoveSDK/Sources/Classes/Optimobile/OverlayMessaging/OptimoveOverlayMessaging.swift
@@ -8,11 +8,11 @@ public class OptimoveOverlayMessaging {
     
     private let manager: OverlayMessagingManager
     private var sessionManager: OverlayMessagingSessionManager?
-    private let sessionLengthHours: Double
+    private let sessionLengthMinutes: Int
     private var initializationToken: NSObjectProtocol?
 
-    private init(sessionLengthHours: Double, httpClient: KSHttpClient, urlBuilder: UrlBuilder) {
-        self.sessionLengthHours = sessionLengthHours
+    private init(sessionLengthMinutes: Int, httpClient: KSHttpClient, urlBuilder: UrlBuilder) {
+        self.sessionLengthMinutes = sessionLengthMinutes
         self.manager = OverlayMessagingManager(httpClient: httpClient, urlBuilder: urlBuilder)
     }
     
@@ -37,7 +37,7 @@ public class OptimoveOverlayMessaging {
     }
     
     static func initialize(config: OptimobileConfig, httpClient: KSHttpClient, urlBuilder: UrlBuilder) {
-        shared = OptimoveOverlayMessaging(sessionLengthHours: config.overlayMessagingSessionLengthHours, httpClient: httpClient, urlBuilder: urlBuilder)
+        shared = OptimoveOverlayMessaging(sessionLengthMinutes: config.overlayMessagingSessionLengthMinutes, httpClient: httpClient, urlBuilder: urlBuilder)
         
         shared?.initializationToken = NotificationCenter.default
             .addObserver(forName: .optimobileInializationFinished, object: nil, queue: nil) { _ in
@@ -52,7 +52,7 @@ public class OptimoveOverlayMessaging {
     
     private func startSessionManager() {
         sessionManager = OverlayMessagingSessionManager(
-            sessionLengthHours: sessionLengthHours,
+            sessionLengthMinutes: sessionLengthMinutes,
             listener: { [weak self] in
                 self?.manager.onTriggerReceived(.session)
             }

--- a/OptimoveSDK/Sources/Classes/Optimobile/OverlayMessaging/OverlayMessagingSessionManager.swift
+++ b/OptimoveSDK/Sources/Classes/Optimobile/OverlayMessaging/OverlayMessagingSessionManager.swift
@@ -15,8 +15,8 @@ class OverlayMessagingSessionManager {
     private var timer: Timer?
     private var appInForeground = false
     
-    init(sessionLengthHours: Double, listener: @escaping SessionStartedListener) {
-        self.sessionLength = sessionLengthHours * 3600.0
+    init(sessionLengthMinutes: Int, listener: @escaping SessionStartedListener) {
+        self.sessionLength = TimeInterval(sessionLengthMinutes) * 60.0
         self.listener = listener
         registerListeners()
     }

--- a/OptimoveSDK/Sources/Classes/Optimobile/OverlayMessaging/OverlayMessagingSessionManager.swift
+++ b/OptimoveSDK/Sources/Classes/Optimobile/OverlayMessaging/OverlayMessagingSessionManager.swift
@@ -15,8 +15,8 @@ class OverlayMessagingSessionManager {
     private var timer: Timer?
     private var appInForeground = false
     
-    init(sessionLengthHours: Int, listener: @escaping SessionStartedListener) {
-        self.sessionLength = TimeInterval(sessionLengthHours) * 3600.0
+    init(sessionLengthHours: Double, listener: @escaping SessionStartedListener) {
+        self.sessionLength = sessionLengthHours * 3600.0
         self.listener = listener
         registerListeners()
     }

--- a/OptimoveSDK/Sources/Classes/OptimoveConfig.swift
+++ b/OptimoveSDK/Sources/Classes/OptimoveConfig.swift
@@ -111,7 +111,7 @@ public struct OptimobileConfig {
     let isRelease: Bool?
 
     let isOverlayMessagingEnabled: Bool
-    let overlayMessagingSessionLengthHours: Double
+    let overlayMessagingSessionLengthMinutes: Int
 }
 
 public typealias Region = OptimobileConfig.Region
@@ -133,7 +133,7 @@ open class OptimoveConfigBuilder: NSObject {
     private var _pushReceivedInForegroundHandlerBlock: Any?
     private var _deepLinkCname: URL?
     private var _deepLinkHandler: DeepLinkHandler?
-    private var _overlayMessagingSessionLengthHours: Double?
+    private var _overlayMessagingSessionLengthMinutes: Int?
     private var _runtimeInfo: [String: AnyObject]?
     private var _sdkInfo: [String: AnyObject]?
     private var _isRelease: Bool?
@@ -183,7 +183,7 @@ open class OptimoveConfigBuilder: NSObject {
             _runtimeInfo = optimobileConfig.runtimeInfo
             _sdkInfo = optimobileConfig.sdkInfo
             _isRelease = optimobileConfig.isRelease
-            _overlayMessagingSessionLengthHours = optimobileConfig.isOverlayMessagingEnabled ? optimobileConfig.overlayMessagingSessionLengthHours : nil
+            _overlayMessagingSessionLengthMinutes = optimobileConfig.isOverlayMessagingEnabled ? optimobileConfig.overlayMessagingSessionLengthMinutes : nil
         }
         features = config.features
     }
@@ -258,10 +258,18 @@ open class OptimoveConfigBuilder: NSObject {
     }
 
     /// Enables Overlay Messaging.
-    /// - Parameter sessionLengthHours: Length of a session, in hours, before overlay triggers can fire again. Must be at least 0.25 (15 minutes).
-    @discardableResult public func enableOverlayMessaging(sessionLengthHours: Double = 1) -> OptimoveConfigBuilder {
-        precondition(sessionLengthHours >= 0.25, "Session duration must be at least 15 minutes.")
-        _overlayMessagingSessionLengthHours = sessionLengthHours
+    /// - Parameter sessionLengthHours: Length of a session, in hours, before overlay triggers can fire again. Must be at least 1.
+    @discardableResult public func enableOverlayMessaging(sessionLengthHours: Int = 1) -> OptimoveConfigBuilder {
+        precondition(sessionLengthHours >= 1, "sessionLengthHours must be at least 1 hour.")
+        _overlayMessagingSessionLengthMinutes = sessionLengthHours * 60
+        return self
+    }
+
+    /// Enables Overlay Messaging.
+    /// - Parameter sessionLengthMinutes: Length of a session, in minutes, before overlay triggers can fire again. Must be at least 15.
+    @discardableResult public func enableOverlayMessaging(sessionLengthMinutes: Int) -> OptimoveConfigBuilder {
+        precondition(sessionLengthMinutes >= 15, "sessionLengthMinutes must be at least 15 minutes.")
+        _overlayMessagingSessionLengthMinutes = sessionLengthMinutes
         return self
     }
 
@@ -385,8 +393,8 @@ open class OptimoveConfigBuilder: NSObject {
                     runtimeInfo: _runtimeInfo,
                     sdkInfo: _sdkInfo,
                     isRelease: _isRelease,
-                    isOverlayMessagingEnabled: _overlayMessagingSessionLengthHours != nil,
-                    overlayMessagingSessionLengthHours: _overlayMessagingSessionLengthHours ?? 1
+                    isOverlayMessagingEnabled: _overlayMessagingSessionLengthMinutes != nil,
+                    overlayMessagingSessionLengthMinutes: _overlayMessagingSessionLengthMinutes ?? 60
                 )
             }
             Logger.info("\(OptimobileConfig.self) building skipped.")

--- a/OptimoveSDK/Sources/Classes/OptimoveConfig.swift
+++ b/OptimoveSDK/Sources/Classes/OptimoveConfig.swift
@@ -111,7 +111,7 @@ public struct OptimobileConfig {
     let isRelease: Bool?
 
     let isOverlayMessagingEnabled: Bool
-    let overlayMessagingSessionLengthHours: Int
+    let overlayMessagingSessionLengthHours: Double
 }
 
 public typealias Region = OptimobileConfig.Region
@@ -133,7 +133,7 @@ open class OptimoveConfigBuilder: NSObject {
     private var _pushReceivedInForegroundHandlerBlock: Any?
     private var _deepLinkCname: URL?
     private var _deepLinkHandler: DeepLinkHandler?
-    private var _overlayMessagingSessionLengthHours: Int?
+    private var _overlayMessagingSessionLengthHours: Double?
     private var _runtimeInfo: [String: AnyObject]?
     private var _sdkInfo: [String: AnyObject]?
     private var _isRelease: Bool?
@@ -257,8 +257,10 @@ open class OptimoveConfigBuilder: NSObject {
         return self
     }
 
-    @discardableResult public func enableOverlayMessaging(sessionLengthHours: Int = 1) -> OptimoveConfigBuilder {
-        precondition(sessionLengthHours >= 1, "sessionLengthHours must be at least 1")
+    /// Enables Overlay Messaging.
+    /// - Parameter sessionLengthHours: Length of a session, in hours, before overlay triggers can fire again. Must be at least 0.25 (15 minutes).
+    @discardableResult public func enableOverlayMessaging(sessionLengthHours: Double = 1) -> OptimoveConfigBuilder {
+        precondition(sessionLengthHours >= 0.25, "Session duration must be at least 15 minutes.")
         _overlayMessagingSessionLengthHours = sessionLengthHours
         return self
     }


### PR DESCRIPTION
1. Add a sessionLengthMinutes overload to OptimoveConfigBuilder.enableOverlayMessaging(...) so customers can configure overlay messaging session windows down to 15 minutes, without changing the existing hours-based API.

- OptimoveConfig.swift: added enableOverlayMessaging(sessionLengthMinutes: Int) (min 15) alongside the existing enableOverlayMessaging(sessionLengthHours: Int = 1) (unchanged, min 1). Both now funnel into an internal overlayMessagingSessionLengthMinutes: Int field.
- OverlayMessagingSessionManager.swift: init now takes sessionLengthMinutes: Int, converting directly to seconds (* 60.0).
- OptimoveOverlayMessaging.swift: storage/param renamed to sessionLengthMinutes: Int to match.
- CHANGELOG.md: documented the new overload.

2. reset overlay session when user associated

Counterpart for https://github.com/optimove-tech/Optimove-SDK-Android/pull/102

