### PR TITLE
AB#292767 fix: stopDispatchTimer starting the timer when called off the main thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.8.1
+
+- Fix `stopDispatchTimer()` starting the dispatch timer instead of stopping it when called off the main thread.
+
 ## 6.8.0
 
 - Add `OptimoveOverlayMessaging.setActionHandler(_:)` — register a handler to intercept overlay CTA clicks and perform custom navigation instead of the SDK opening the URL.

--- a/OptimoveCore.podspec
+++ b/OptimoveCore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'OptimoveCore'
-  s.version          = '6.8.0'
+  s.version          = '6.8.1'
   s.summary          = 'Official Optimove SDK for iOS. Core framework.'
   s.description      = 'The core framework is used to share code-base between other Optimove frameworks.'
   s.homepage         = 'https://github.com/optimove-tech/Optimove-SDK-iOS'

--- a/OptimoveCore/Sources/Classes/Constants/SDKVersion.swift
+++ b/OptimoveCore/Sources/Classes/Constants/SDKVersion.swift
@@ -1,3 +1,3 @@
 //  Copyright © 2019 Optimove. All rights reserved.
 
-public let SDKVersion = "6.8.0"
+public let SDKVersion = "6.8.1"

--- a/OptimoveNotificationServiceExtension.podspec
+++ b/OptimoveNotificationServiceExtension.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'OptimoveNotificationServiceExtension'
-  s.version          = '6.8.0'
+  s.version          = '6.8.1'
   s.summary          = 'Official Optimove SDK for iOS. Notification service extension framework.'
   s.description      = 'The notification service extension is used for handling additional content in push notifications.'
   s.homepage         = 'https://github.com/optimove-tech/Optimove-SDK-iOS'

--- a/OptimoveSDK.podspec
+++ b/OptimoveSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'OptimoveSDK'
-  s.version          = '6.8.0'
+  s.version          = '6.8.1'
   s.summary          = 'Official Optimove SDK for iOS.'
   s.description      = 'The Optimove SDK framework is used for reporting events and receive push notifications.'
   s.homepage         = 'https://github.com/optimove-tech/Optimove-SDK-iOS'

--- a/OptimoveSDK/Sources/Classes/Components/OptiTrack/OptiTrack.swift
+++ b/OptimoveSDK/Sources/Classes/Components/OptiTrack/OptiTrack.swift
@@ -106,7 +106,7 @@ private extension OptiTrack {
     func stopDispatchTimer() {
         guard Thread.isMainThread else {
             DispatchQueue.main.sync {
-                self.startDispatchTimer()
+                self.stopDispatchTimer()
             }
             return
         }


### PR DESCRIPTION
### Description of Changes

`OptiTrack.stopDispatchTimer()` called `startDispatchTimer()` when invoked off the main
thread, so every off-main stop **started** the dispatch timer instead of stopping it.

```diff
     func stopDispatchTimer() {
         guard Thread.isMainThread else {
             DispatchQueue.main.sync {
-                self.startDispatchTimer()
+                self.stopDispatchTimer()
             }
             return
         }
```

This is a cherry-pick of `10aabcc1` (Christopher Wyllie, 2022-04-29) from the
`fix-dispatch-timer` branch, which was never merged. Original authorship is preserved.
The branch it sat on is 208 commits behind `master`; the single-line change cherry-picks
cleanly onto current `master`.

Second commit bumps the patch version to 6.8.1.

### Breaking Changes

-   None

### Release Checklist

### Prepare:

- [x] Detail any breaking changes. Breaking changes require a new major version number — none; patch release
- [ ] Check `pod lib lint` passes
- [ ] Update any relevant sections of the repository wiki pages on a branch — n/a, no public API change

### Bump versions in:

- [x] `OptimoveCore.podspec`
- [x] `OptimoveNotificationServiceExtension.podspec`
- [x] `OptimoveSDK.podspec`

- [x] `OptimoveCore/Sources/Classes/Constants/SDKVersion.swift`

- [ ] `README.md` — n/a, contains no version reference
- [x] `CHANGELOG.md`

- [ ] Update major version numbers in wiki (basic integration + push guides) — n/a, patch release

### Integration tests

Unit tests run locally on the `UnitTests` scheme (iPhone 15, iOS 17.5): **75 tests,
0 failures**. Manual integration checklist below not exercised — the change is confined
to timer invalidation on the event-dispatch path.

*T&T Only*

- [ ] Init SDK with only T&T credentials
- [ ] Associate customer
- [ ] Associate email
- [ ] Track events

*Mobile Only*

- [ ] Init SDK with all credentials
- [ ] Track events
- [ ] Associate customer (verify both backends)
- [ ] Register for push
- [ ] Opt-in for In-App
- [ ] Send test push
- [ ] Send test In-App
- [ ] Receive / trigger deep link handler (In-App/Push)
- [ ] Receive / trigger the content extension, render image and action buttons for push
- [ ] Verify push opened handler

*Deferred Deep Links*

- [ ] With app installed, trigger deep link handler
- [ ] With app uninstalled, follow deep link, install test bundle, verify deep link read from Clipboard, trigger deep link handler

*Combined*

- [ ] Track event for T&T, verify push received
- [ ] Trigger scheduled campaign, verify push received
- [ ] Trigger scheduled campaign, verify In-App received

### Release:

- [ ] Squash and merge to master
- [ ] Delete branch once merged
- [ ] Create tag from master matching chosen version
- [ ] Run `pod trunk push` to publish to CocoaPods

### Post Release:

- [ ] Push wiki pages to master
