### PR TITLE
AB#292772 build: resolve test toolchain and simulator instead of hard-pinning

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,3 +7,6 @@ jobs:
       - uses: actions/checkout@v1
       - run: make test
         name: Test
+        env:
+          # CI must use the pinned Xcode, never silently fall back to another one.
+          XCODE_STRICT: 1

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ derived_data_path = ${build_path}/derived_data
 
 .PHONY: setup
 setup:
-	test -n "${DEVELOPER_DIR}"
+	test -d "${DEVELOPER_DIR}"
 	brew bundle --file=./Brewfile --quiet || echo "brew bundle failed; xcbeautify and swiftformat may be missing." 1>&2
 
 .PHONY: all

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,11 @@
+# Preferred Xcode version. When it isn't installed the scripts fall back to the
+# active toolchain; set XCODE_STRICT=1 to require an exact match instead.
 XCODE ?= 15.2
 
-export TEST_DESTINATION ?= platform=iOS Simulator,OS=17.7,name=iPhone 15
+# Optional override for the simulator to test on, e.g.
+#   make test TEST_DESTINATION="platform=iOS Simulator,OS=18.0,name=iPhone 16"
+# When unset, scripts/resolve-test-destination.sh picks an available simulator.
+export TEST_DESTINATION
 export DEVELOPER_DIR = $(shell bash ./scripts/get-xcode-path.sh ${XCODE} $(XCODE_PATH))
 
 build_path = .build
@@ -8,8 +13,8 @@ derived_data_path = ${build_path}/derived_data
 
 .PHONY: setup
 setup:
-	test ${DEVELOPER_DIR}
-	brew bundle --file=./Brewfile --quiet
+	test -n "${DEVELOPER_DIR}"
+	brew bundle --file=./Brewfile --quiet || echo "brew bundle failed; xcbeautify and swiftformat may be missing." 1>&2
 
 .PHONY: all
 all: setup format headers test clean

--- a/configurations/test.xcconfig
+++ b/configurations/test.xcconfig
@@ -1,5 +1,5 @@
 SCHEME="UnitTests"
 PROJECT="Optimove.xcodeproj"
 SDK="iphonesimulator"
-DESTANATION="platform=iOS Simulator,name=iPhone 15"
+DEVICE_NAME="iPhone 15"
 CONFIGURATION="Debug"

--- a/scripts/build-for-testing.sh
+++ b/scripts/build-for-testing.sh
@@ -7,8 +7,11 @@ set -x
 # Set the project variables
 source $PWD/configurations/test.xcconfig
 
-# Resolve a simulator that exists on this machine (honors TEST_DESTINATION)
+# Resolve a simulator that exists on this machine (honors TEST_DESTINATION) and
+# record it, so test-without-building runs on the device we built products for
 DESTINATION=$(bash "$(dirname "$0")/resolve-test-destination.sh" "$DEVICE_NAME")
+mkdir -p "$1"
+echo "$DESTINATION" >"$1/test-destination"
 
 # xcbeautify only prettifies the log, so run without it when it isn't installed
 if command -v xcbeautify >/dev/null 2>&1; then

--- a/scripts/build-for-testing.sh
+++ b/scripts/build-for-testing.sh
@@ -7,14 +7,25 @@ set -x
 # Set the project variables
 source $PWD/configurations/test.xcconfig
 
+# Resolve a simulator that exists on this machine (honors TEST_DESTINATION)
+DESTINATION=$(bash "$(dirname "$0")/resolve-test-destination.sh" "$DEVICE_NAME")
+
+# xcbeautify only prettifies the log, so run without it when it isn't installed
+if command -v xcbeautify >/dev/null 2>&1; then
+    FORMATTER=(xcbeautify)
+else
+    echo "xcbeautify not found, using raw xcodebuild output. Run 'make setup' to install it." 1>&2
+    FORMATTER=(cat)
+fi
+
 # Build the project
 xcodebuild build-for-testing \
     -scheme "$SCHEME" \
     -project "$PROJECT" \
-    -destination "$DESTANATION" \
+    -destination "$DESTINATION" \
     -sdk "$SDK" \
     -configuration "$CONFIGURATION" \
     -derivedDataPath $1 |
-    xcbeautify
+    "${FORMATTER[@]}"
 
 echo "Process completed successfully."

--- a/scripts/build-for-testing.sh
+++ b/scripts/build-for-testing.sh
@@ -28,7 +28,7 @@ xcodebuild build-for-testing \
     -destination "$DESTINATION" \
     -sdk "$SDK" \
     -configuration "$CONFIGURATION" \
-    -derivedDataPath $1 |
+    -derivedDataPath "$1" |
     "${FORMATTER[@]}"
 
 echo "Process completed successfully."

--- a/scripts/get-xcode-path.sh
+++ b/scripts/get-xcode-path.sh
@@ -39,7 +39,7 @@ for APP in $XCODE_APPS; do
     fi
 done
 
-echo "Failed to find Xcode $XCODE_ARG. Available versions: " 1>&2
+echo "Requested Xcode $XCODE_ARG not found. Available versions: " 1>&2
 
 for APP in $XCODE_APPS; do
     APP_VERSION=$(get_version $APP)
@@ -49,12 +49,13 @@ done
 # Pinning an Xcode version that isn't installed should not make every target
 # unrunnable. Fall back to the active toolchain and say so, unless the caller
 # asked for a strict match (CI does, so a missing pinned Xcode fails loudly).
-if [ -n "$XCODE_STRICT" ]; then
+if [ -n "$XCODE_STRICT" ] && [ "$XCODE_STRICT" != "0" ]; then
     echo "XCODE_STRICT is set, refusing to fall back." 1>&2
     exit 1
 fi
 
-ACTIVE_XCODE=$(xcode-select -p 2>/dev/null)
+# Keep the failure non-fatal under `set -e` so the check below reports it.
+ACTIVE_XCODE=$(xcode-select -p 2>/dev/null) || true
 
 if [ -z "$ACTIVE_XCODE" ]; then
     echo "No active Xcode found via xcode-select." 1>&2

--- a/scripts/get-xcode-path.sh
+++ b/scripts/get-xcode-path.sh
@@ -39,11 +39,28 @@ for APP in $XCODE_APPS; do
     fi
 done
 
-echo "Failed to find $XCODE_ARG. Available versions: " 1>&2
+echo "Failed to find Xcode $XCODE_ARG. Available versions: " 1>&2
 
 for APP in $XCODE_APPS; do
     APP_VERSION=$(get_version $APP)
     echo "$APP_VERSION: $APP" 1>&2
 done
 
-exit 1
+# Pinning an Xcode version that isn't installed should not make every target
+# unrunnable. Fall back to the active toolchain and say so, unless the caller
+# asked for a strict match (CI does, so a missing pinned Xcode fails loudly).
+if [ -n "$XCODE_STRICT" ]; then
+    echo "XCODE_STRICT is set, refusing to fall back." 1>&2
+    exit 1
+fi
+
+ACTIVE_XCODE=$(xcode-select -p 2>/dev/null)
+
+if [ -z "$ACTIVE_XCODE" ]; then
+    echo "No active Xcode found via xcode-select." 1>&2
+    exit 1
+fi
+
+echo "Falling back to the active toolchain: $ACTIVE_XCODE" 1>&2
+echo "Pass XCODE=<version> to pick another, or XCODE_STRICT=1 to fail instead." 1>&2
+echo "$ACTIVE_XCODE"

--- a/scripts/resolve-test-destination.sh
+++ b/scripts/resolve-test-destination.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# resolve-test-destination.sh [PREFERRED_DEVICE_NAME]
+#
+# Emits an xcodebuild -destination specifier for an iOS simulator that actually
+# exists on this machine.
+#
+# A name-only destination such as "platform=iOS Simulator,name=iPhone 15" is
+# resolved by xcodebuild against OS:latest. When the newest installed runtime has
+# no device by that name, xcodebuild fails with "Unable to find a device matching
+# the provided destination specifier" instead of falling back to an older runtime.
+# Resolving to a concrete UDID here avoids depending on which runtimes happen to
+# be installed.
+#
+# Set TEST_DESTINATION to bypass resolution entirely.
+
+set -o pipefail
+set -e
+
+if [ -n "$TEST_DESTINATION" ]; then
+    echo "$TEST_DESTINATION"
+    exit 0
+fi
+
+PREFERRED_NAME="${1:-}"
+
+# "<os-version>|<device-name>|<udid>" for every booted-or-bootable iOS simulator,
+# oldest runtime first.
+DEVICES=$(
+    xcrun simctl list devices available |
+        awk '
+            /^-- iOS /              { os = $3; next }
+            /^-- /                  { os = "";  next }
+            os == ""                { next }
+            match($0, /\(([0-9A-Fa-f-]{36})\)/) {
+                udid = substr($0, RSTART + 1, RLENGTH - 2)
+                name = $0
+                sub(/^[[:space:]]+/, "", name)
+                sub(/[[:space:]]+\([0-9A-Fa-f-]{36}\).*$/, "", name)
+                print os "|" name "|" udid
+            }
+        ' | sort -t'|' -k1,1V
+)
+
+if [ -z "$DEVICES" ]; then
+    echo "No available iOS simulators found. Install a simulator runtime via Xcode > Settings > Components." 1>&2
+    exit 1
+fi
+
+# Prefer the requested device on the newest runtime that has it, then any iPhone,
+# then whatever is left.
+MATCH=""
+if [ -n "$PREFERRED_NAME" ]; then
+    MATCH=$(echo "$DEVICES" | awk -F'|' -v n="$PREFERRED_NAME" '$2 == n' | tail -1)
+fi
+if [ -z "$MATCH" ]; then
+    MATCH=$(echo "$DEVICES" | awk -F'|' '$2 ~ /^iPhone/' | tail -1)
+fi
+if [ -z "$MATCH" ]; then
+    MATCH=$(echo "$DEVICES" | tail -1)
+fi
+
+OS_VERSION=$(echo "$MATCH" | cut -d'|' -f1)
+DEVICE_NAME=$(echo "$MATCH" | cut -d'|' -f2)
+UDID=$(echo "$MATCH" | cut -d'|' -f3)
+
+if [ -n "$PREFERRED_NAME" ] && [ "$DEVICE_NAME" != "$PREFERRED_NAME" ]; then
+    echo "Note: '$PREFERRED_NAME' is not available; using '$DEVICE_NAME' (iOS $OS_VERSION)." 1>&2
+fi
+
+echo "platform=iOS Simulator,id=$UDID"

--- a/scripts/resolve-test-destination.sh
+++ b/scripts/resolve-test-destination.sh
@@ -24,13 +24,15 @@ fi
 PREFERRED_NAME="${1:-}"
 
 # "<os-version>|<device-name>|<udid>" for every booted-or-bootable iOS simulator,
-# oldest runtime first.
+# oldest runtime first. Clones are skipped: xcodebuild creates them for parallel
+# testing, so they appear mid-run and would make repeated resolution unstable.
 DEVICES=$(
     xcrun simctl list devices available |
         awk '
             /^-- iOS /              { os = $3; next }
             /^-- /                  { os = "";  next }
             os == ""                { next }
+            /Clone [0-9]+ of /      { next }
             match($0, /\(([0-9A-Fa-f-]{36})\)/) {
                 udid = substr($0, RSTART + 1, RLENGTH - 2)
                 name = $0

--- a/scripts/test-without-building.sh
+++ b/scripts/test-without-building.sh
@@ -33,7 +33,7 @@ xcodebuild test-without-building \
     -destination "$DESTINATION" \
     -sdk "$SDK" \
     -configuration "$CONFIGURATION" \
-    -derivedDataPath $1 |
+    -derivedDataPath "$1" |
     "${FORMATTER[@]}"
 
 echo "Process completed successfully."

--- a/scripts/test-without-building.sh
+++ b/scripts/test-without-building.sh
@@ -7,14 +7,25 @@ set -x
 # Set the project variables
 source $PWD/configurations/test.xcconfig
 
+# Resolve a simulator that exists on this machine (honors TEST_DESTINATION)
+DESTINATION=$(bash "$(dirname "$0")/resolve-test-destination.sh" "$DEVICE_NAME")
+
+# xcbeautify only prettifies the log, so run without it when it isn't installed
+if command -v xcbeautify >/dev/null 2>&1; then
+    FORMATTER=(xcbeautify)
+else
+    echo "xcbeautify not found, using raw xcodebuild output. Run 'make setup' to install it." 1>&2
+    FORMATTER=(cat)
+fi
+
 # Test the project
 xcodebuild test-without-building \
     -scheme "$SCHEME" \
     -project "$PROJECT" \
-    -destination "$DESTANATION" \
+    -destination "$DESTINATION" \
     -sdk "$SDK" \
     -configuration "$CONFIGURATION" \
     -derivedDataPath $1 |
-    xcbeautify
+    "${FORMATTER[@]}"
 
 echo "Process completed successfully."

--- a/scripts/test-without-building.sh
+++ b/scripts/test-without-building.sh
@@ -7,8 +7,16 @@ set -x
 # Set the project variables
 source $PWD/configurations/test.xcconfig
 
-# Resolve a simulator that exists on this machine (honors TEST_DESTINATION)
-DESTINATION=$(bash "$(dirname "$0")/resolve-test-destination.sh" "$DEVICE_NAME")
+# Reuse the destination build-for-testing resolved. Resolving independently can
+# pick a different device, because xcodebuild adds simulator clones for parallel
+# testing while it runs, and there would be no built products for that device.
+if [ -n "$TEST_DESTINATION" ]; then
+    DESTINATION="$TEST_DESTINATION"
+elif [ -f "$1/test-destination" ]; then
+    DESTINATION=$(cat "$1/test-destination")
+else
+    DESTINATION=$(bash "$(dirname "$0")/resolve-test-destination.sh" "$DEVICE_NAME")
+fi
 
 # xcbeautify only prettifies the log, so run without it when it isn't installed
 if command -v xcbeautify >/dev/null 2>&1; then


### PR DESCRIPTION
### Description of Changes

`make test` could not run on a machine without Xcode 15.2 plus an iPhone 15 simulator on
the newest installed iOS runtime. Four independent blockers, all in the build tooling — no
SDK source is touched.

**1. A missing pinned Xcode broke every target.** `scripts/get-xcode-path.sh` exited `1`
when `XCODE` (default `15.2`) wasn't installed, so `test ${DEVELOPER_DIR}` in `setup`
failed and nothing downstream could run. It now falls back to the active toolchain and says
so on stderr. `XCODE_STRICT=1` restores the hard failure, and the CI workflow sets it, so
CI still refuses to silently build with a different Xcode.

**2. The simulator destination was unresolvable.** `test.xcconfig` specified
`platform=iOS Simulator,name=iPhone 15` with no OS, and xcodebuild resolves a name-only
destination against `OS:latest`:

```
xcodebuild: error: Unable to find a device matching the provided destination specifier:
		{ platform:iOS Simulator, OS:latest, name:iPhone 15 }
```

With a newer Xcode installed, `latest` is a runtime that has no iPhone 15, and xcodebuild
fails rather than falling back to an older one. New `scripts/resolve-test-destination.sh`
resolves a concrete simulator UDID: preferred device on the newest runtime that has it,
else the newest available iPhone, else any available simulator.

**3. `xcbeautify` was mandatory.** Its pipe ran under `set -o pipefail`, so a missing
`xcbeautify` failed the build even though it only prettifies the log. Now optional, with a
notice.

**4. `brew bundle` in `setup` was fatal**, requiring Homebrew just to run tests. Now
non-fatal — the tools it installs are only needed by `format` and for pretty output.

Also: `TEST_DESTINATION` was exported by the Makefile but never read — the scripts sourced
`DESTANATION` from `test.xcconfig`. It is now a real override
(`make test TEST_DESTINATION="..."`), and the misspelled variable is renamed to
`DEVICE_NAME`, which is what it actually is now.

**5. The two scripts could resolve different simulators.** Caught by the first CI run on
this branch, not by local testing:

```
build-for-testing:     id=287A7916-2BD1-4674-8A22-38756D5658F4
test-without-building: id=F7860BC6-707F-40C6-8B2C-D38ECCD7AE42
```

`xcodebuild` adds `Clone N of <device>` simulators for parallel testing *while it runs*, so
the device list is not stable between the two invocations. `build-for-testing` now records
the destination it used under the derived data path and `test-without-building` reuses it,
so tests always run on the device the products were built for. The resolver also skips
clones. An explicit `TEST_DESTINATION` still takes precedence.

#### Verification

Ran the exact commands `make test` runs after `setup`, on Xcode 26.6 with no `xcbeautify`
installed — the configuration that previously failed outright:

```
+ DESTINATION='platform=iOS Simulator,id=B0EDFCCF-E1FF-463D-B0F0-76D614D930DE'
xcbeautify not found, using raw xcodebuild output. Run 'make setup' to install it.
Executed 75 tests, with 0 failures (0 unexpected) in 8.826 seconds
```

`build-for-testing` and `test-without-building` both exit 0. Resolver checked for: preferred
device present, preferred device absent (falls back + warns), no preference, and
`TEST_DESTINATION` override. `get-xcode-path.sh` checked for: missing pinned version
(falls back, exit 0), `XCODE_STRICT=1` (exit 1), and an installed version (resolves
normally).

Not exercised locally: the `brew bundle` line, since running it would install `xcbeautify`
and `swiftformat` on this machine. CI will exercise it.

Note: `scripts/check-headers.sh` fails on `master` independently of this change (its
`if [[ $? == 0 ]]` after `git grep -L` is unreachable-false under `set -e`, so it always
reports an error). Left alone — it only covers `*.{h,m,mm,swift}` and excludes
`scripts/**`, and CI does not run `make headers`.

#### CI on this branch is red for a pre-existing reason

`AnalyticsHelperTests` fails with 5 tests / 1 failure in ~14s. `master` fails identically
(run `27026033610`), as do 4 of its last 6 runs, so the red build predates this branch and
is not caused by it. The 14s runtime points at the `DispatchSemaphore` barrier in
`AnalyticsHelper`. Worth its own PR.

`SessionHelperTests` is separately flaky — it asserts `elapsedMs < 100` and depends on
2.0s/2.5s async delays, which is unreliable on a loaded runner. It passes consistently
locally and passed on a same-commit CI re-run.

### Breaking Changes

-   None

### Release Checklist

Build tooling only — no shipped code changes, so no version bump or release.

### Prepare:

- [x] Detail any breaking changes. Breaking changes require a new major version number — none
- [ ] Check `pod lib lint` passes — n/a, no podspec or source change
- [ ] Update any relevant sections of the repository wiki pages on a branch — n/a

### Bump versions in:

n/a — no release.

### Integration tests

n/a — no runtime code changed. Unit tests pass: 75 tests, 0 failures.

### Release:

n/a — no release.
