### PR TITLE
AB#292773 test: make the SessionHelper tests deterministic

### DIFF
--- a/OptimoveSDK/Tests/Sources/Optimobile/AnalyticsHelperTests.swift
+++ b/OptimoveSDK/Tests/Sources/Optimobile/AnalyticsHelperTests.swift
@@ -22,12 +22,31 @@ class AnalyticsHelperTests: XCTestCase {
         analyticsHelper = AnalyticsHelper(httpClient: mockHttpClient)
     }
 
+    // AnalyticsHelper picks its store the same way, and in this test bundle an app
+    // group IS defined, so the store it actually uses is KAnalyticsDbShared.sqlite
+    // in the group container. Deleting only KAnalyticsDb.sqlite under Documents
+    // removed a file that never exists, so the store was never cleared and events
+    // accumulated across every test in this class. A single event left behind by an
+    // earlier test is enough to break the strict count assertions below, because
+    // the next flush picks it up and delivers it to that test's mock.
     private func clearAnalyticsStore() {
-        guard let docsUrl = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).last else { return }
-        let dbUrl = docsUrl.appendingPathComponent("KAnalyticsDb.sqlite")
-        for suffix in ["", "-shm", "-wal"] {
-            let url = dbUrl.deletingLastPathComponent().appendingPathComponent(dbUrl.lastPathComponent + suffix)
-            try? FileManager.default.removeItem(at: url)
+        var stores: [URL] = []
+
+        if let docsUrl = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).last,
+           let appDb = URL(string: "KAnalyticsDb.sqlite", relativeTo: docsUrl) {
+            stores.append(appDb.absoluteURL)
+        }
+
+        if let sharedContainerPath = AppGroupsHelper.getSharedContainerPath(),
+           let sharedDb = URL(string: "KAnalyticsDbShared.sqlite", relativeTo: sharedContainerPath) {
+            stores.append(sharedDb.absoluteURL)
+        }
+
+        for store in stores {
+            for suffix in ["", "-shm", "-wal"] {
+                let url = store.deletingLastPathComponent().appendingPathComponent(store.lastPathComponent + suffix)
+                try? FileManager.default.removeItem(at: url)
+            }
         }
     }
 

--- a/OptimoveSDK/Tests/Sources/Optimobile/AnalyticsHelperTests.swift
+++ b/OptimoveSDK/Tests/Sources/Optimobile/AnalyticsHelperTests.swift
@@ -10,11 +10,11 @@ import XCTest
 import OptimoveTest
 
 class AnalyticsHelperTests: XCTestCase {
-
+    
     var mockHttpClient: MockKSHttpClient!
     var analyticsHelper: AnalyticsHelper!
     var longTimeoutInSeconds = 10.0
-
+    
     override func setUp() {
         super.setUp()
         clearAnalyticsStore()
@@ -22,202 +22,134 @@ class AnalyticsHelperTests: XCTestCase {
         analyticsHelper = AnalyticsHelper(httpClient: mockHttpClient)
     }
 
-    // AnalyticsHelper picks its store the same way, and in this test bundle an app
-    // group IS defined, so the store it actually uses is KAnalyticsDbShared.sqlite
-    // in the group container. Deleting only KAnalyticsDb.sqlite under Documents
-    // removed a file that never exists, so the store was never cleared and events
-    // accumulated across every test in this class. A single event left behind by an
-    // earlier test is enough to break the strict count assertions below, because
-    // the next flush picks it up and delivers it to that test's mock.
     private func clearAnalyticsStore() {
-        var stores: [URL] = []
-
-        if let docsUrl = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).last,
-           let appDb = URL(string: "KAnalyticsDb.sqlite", relativeTo: docsUrl) {
-            stores.append(appDb.absoluteURL)
-        }
-
-        if let sharedContainerPath = AppGroupsHelper.getSharedContainerPath(),
-           let sharedDb = URL(string: "KAnalyticsDbShared.sqlite", relativeTo: sharedContainerPath) {
-            stores.append(sharedDb.absoluteURL)
-        }
-
-        for store in stores {
-            for suffix in ["", "-shm", "-wal"] {
-                let url = store.deletingLastPathComponent().appendingPathComponent(store.lastPathComponent + suffix)
-                try? FileManager.default.removeItem(at: url)
-            }
+        guard let docsUrl = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).last else { return }
+        let dbUrl = docsUrl.appendingPathComponent("KAnalyticsDb.sqlite")
+        for suffix in ["", "-shm", "-wal"] {
+            let url = dbUrl.deletingLastPathComponent().appendingPathComponent(dbUrl.lastPathComponent + suffix)
+            try? FileManager.default.removeItem(at: url)
         }
     }
-
+    
     override func tearDown()
     {
         analyticsHelper = nil
         mockHttpClient = nil
         super.tearDown()
     }
-
-    // A flush completion can outlive waitForExpectations, and tearDown then sets
-    // mockHttpClient and analyticsHelper to nil. Reading them through self from
-    // inside a completion crashes the whole test binary on the implicit unwrap,
-    // which shows up as an unrelated test failing later in the run. Capture what
-    // the completion needs before tracking, so it holds its own strong reference.
-
+    
     func test_number_of_sent_events_same_as_tracked() {
-        let helper = analyticsHelper!
-        let mock = mockHttpClient!
         let numberOfEvents = 4
         let numberOfEventsExpectation = expectation(description: "Number of events wasnt \(numberOfEvents)")
-
+        
         for i in 1...numberOfEvents - 1 {
-            helper.trackEvent(eventType: "immediate_event\(i)", properties: nil, immediateFlush: true)
+            analyticsHelper.trackEvent(eventType: "immediate_event\(i)", properties: nil, immediateFlush: true)
         }
-
-        helper.trackEvent(eventType: "immediate_event_last", atTime: Date(), properties: nil, immediateFlush: true) {_ in
-            if let data = mock.capturedData as? [[String: Any?]], data.count == numberOfEvents {
+        
+        self.analyticsHelper.trackEvent(eventType: "immediate_event_last", atTime: Date(), properties: nil, immediateFlush: true) {_ in
+            if let data = self.mockHttpClient.capturedData as? [[String: Any?]], data.count == numberOfEvents {
                 numberOfEventsExpectation.fulfill()
             }
         }
-
-        wait(for: [numberOfEventsExpectation], timeout: longTimeoutInSeconds)
+        
+        waitForExpectations(timeout: longTimeoutInSeconds, handler: nil)
     }
-
+    
     func test_number_of_sent_events_with_delays_same_as_tracked() {
-        let helper = analyticsHelper!
-        let mock = mockHttpClient!
         let numberOfEvents = 4
-
-        // The point of this test is that events tracked in a later, separate flush
-        // are still all delivered. Waiting for the first flush to report completion
-        // establishes that separation directly. A sleep only made it likely, and
-        // spent 2 of the 10 second budget doing nothing, which is what tipped this
-        // test into timing out on a loaded CI runner.
-        let firstEventFlushed = expectation(description: "First event was flushed")
-        helper.trackEvent(eventType: "immediate_event_first", atTime: Date(), properties: nil, immediateFlush: true) {_ in
-            firstEventFlushed.fulfill()
-        }
-        wait(for: [firstEventFlushed], timeout: longTimeoutInSeconds)
-
-        let numberOfEventsExpectation = expectation(description: "Number of events wasnt \(numberOfEvents + 1)")
-
-        for i in 1...numberOfEvents - 1 {
-            helper.trackEvent(eventType: "immediate_event\(i)", properties: nil, immediateFlush: true)
-        }
-
-        helper.trackEvent(eventType: "immediate_event_last", atTime: Date(), properties: nil, immediateFlush: true) {_ in
-            // +1 for immediate_event_first tracked before the first flush
-            if mock.totalEventCount == numberOfEvents + 1 {
-                numberOfEventsExpectation.fulfill()
+        let numberOfEventsExpectation = expectation(description: "Number of events wasnt \(numberOfEvents)")
+        
+        analyticsHelper.trackEvent(eventType: "immediate_event_first", properties: nil, immediateFlush: true)
+        
+        DispatchQueue.global().asyncAfter(deadline: .now() + 2) {
+            for i in 1...numberOfEvents - 1 {
+                self.analyticsHelper.trackEvent(eventType: "immediate_event\(i)", properties: nil, immediateFlush: true)
             }
-        }
-
-        wait(for: [numberOfEventsExpectation], timeout: longTimeoutInSeconds)
-    }
-
-    func test_number_of_sent_events_from_background_threads_same_as_tracked() {
-        let helper = analyticsHelper!
-        let mock = mockHttpClient!
-        let numberOfEvents = 4
-
-        // Nothing ordered the background blocks before the final event, so if they
-        // had not been scheduled yet the final flush completed against a smaller
-        // store. The completion only runs once, so it never re-checked and the test
-        // sat out its whole timeout. Wait for the background events to be flushed
-        // before tracking the last one; they are still issued concurrently, which is
-        // what this test is about.
-        let backgroundEventsFlushed = expectation(description: "Background events weren't flushed")
-        backgroundEventsFlushed.expectedFulfillmentCount = numberOfEvents - 1
-
-        for i in 1...numberOfEvents - 1 {
-            DispatchQueue.global().async {
-                helper.trackEvent(eventType: "immediate_event\(i)", atTime: Date(), properties: nil, immediateFlush: true) {_ in
-                    backgroundEventsFlushed.fulfill()
+            
+            self.analyticsHelper.trackEvent(eventType: "immediate_event_last", atTime: Date(), properties: nil, immediateFlush: true) {_ in
+                // +1 for immediate_event_first tracked before the delay
+                let count = self.mockHttpClient.totalEventCount
+            
+                if self.mockHttpClient.totalEventCount == numberOfEvents + 1 {
+                    numberOfEventsExpectation.fulfill()
                 }
             }
         }
-
-        wait(for: [backgroundEventsFlushed], timeout: longTimeoutInSeconds)
-
+        
+        waitForExpectations(timeout: longTimeoutInSeconds, handler: nil)
+    }
+    
+    func test_number_of_sent_events_from_background_threads_same_as_tracked() {
+        let numberOfEvents = 4
         let numberOfEventsExpectation = expectation(description: "Number of events wasnt \(numberOfEvents)")
-
-        helper.trackEvent(eventType: "immediate_event_last", atTime: Date(), properties: nil, immediateFlush: true) {_ in
-            if let data = mock.capturedData as? [[String: Any?]], data.count == numberOfEvents {
+    
+        
+        for i in 1...numberOfEvents - 1 {
+            DispatchQueue.global().async {
+                self.analyticsHelper.trackEvent(eventType: "immediate_event\(i)", properties: nil, immediateFlush: true)
+            }
+        }
+        
+        analyticsHelper.trackEvent(eventType: "immediate_event_last", atTime: Date(), properties: nil, immediateFlush: true) {_ in
+            if let data = self.mockHttpClient.capturedData as? [[String: Any?]], data.count == numberOfEvents {
                 numberOfEventsExpectation.fulfill()
             }
         }
-
-        wait(for: [numberOfEventsExpectation], timeout: longTimeoutInSeconds)
+        
+        waitForExpectations(timeout: longTimeoutInSeconds, handler: nil)
     }
-
+    
     func test_immediate_event_should_grab_nonimmediate() {
-        let helper = analyticsHelper!
-        let mock = mockHttpClient!
         let nonImmediateSentExpectation = expectation(description: "Non immediate wasn't sent with immediate")
-
-        helper.trackEvent(eventType: "regular_event", properties: nil, immediateFlush: false)
-        helper.trackEvent(eventType: "immediate_event", atTime: Date(), properties: nil, immediateFlush: true) {_ in
-            if let data = mock.capturedData as? [[String: Any?]], data.count == 2 {
+    
+        
+        analyticsHelper.trackEvent(eventType: "regular_event", properties: nil, immediateFlush: false)
+        analyticsHelper.trackEvent(eventType: "immediate_event", atTime: Date(), properties: nil, immediateFlush: true) {_ in
+            if let data = self.mockHttpClient.capturedData as? [[String: Any?]], data.count == 2 {
                 nonImmediateSentExpectation.fulfill()
             }
         }
-
-        wait(for: [nonImmediateSentExpectation], timeout: longTimeoutInSeconds)
+        
+        waitForExpectations(timeout: longTimeoutInSeconds, handler: nil)
     }
-
+    
     func test_failed_network_event_should_be_picked_up_by_subsequent() {
         let mockKSHttpClientSingleFailure = MockKSHttpClientSingleFailure()
         let analyticsHelper = AnalyticsHelper(httpClient: mockKSHttpClientSingleFailure)
-
-        // Wait for the send to actually fail instead of sleeping and assuming it
-        // has, so the second event is guaranteed to be the subsequent dispatch.
-        let firstSendFailed = expectation(description: "First send wasn't failed")
-        mockKSHttpClientSingleFailure.onFailureDelivered = { firstSendFailed.fulfill() }
-
-        analyticsHelper.trackEvent(eventType: "immeditate_event", properties: nil, immediateFlush: true)
-        wait(for: [firstSendFailed], timeout: longTimeoutInSeconds)
-
+        
         let failedEventExpectation = expectation(description: "Failed event wasn't sent on next dispatch")
 
-        analyticsHelper.trackEvent(eventType: "immediate_event_second", atTime: Date(), properties: nil, immediateFlush: true) {_ in
-            if let data = mockKSHttpClientSingleFailure.capturedData as? [[String: Any?]], data.count == 2 {
-                failedEventExpectation.fulfill()
+        analyticsHelper.trackEvent(eventType: "immeditate_event", properties: nil, immediateFlush: true)
+        
+        DispatchQueue.global().asyncAfter(deadline: .now() + 2) {
+            analyticsHelper.trackEvent(eventType: "immediate_event_second", atTime: Date(), properties: nil, immediateFlush: true) {_ in
+                if let data = mockKSHttpClientSingleFailure.capturedData as? [[String: Any?]], data.count == 2 {
+                    failedEventExpectation.fulfill()
+                }
             }
         }
-
-        wait(for: [failedEventExpectation], timeout: longTimeoutInSeconds)
+        
+        waitForExpectations(timeout: longTimeoutInSeconds, handler: nil)
     }
-
+    
 }
 
 class MockKSHttpClient: KSHttpClient {
-    // Written on whichever queue AnalyticsHelper flushes from and read from test
-    // completions, so every access is behind the lock.
-    private let lock = NSLock()
     private var allBatches: [[String: Any?]] = []
 
-    // Every event delivered so far, across all requests, in delivery order
-    var capturedData: Any? {
-        lock.lock()
-        defer { lock.unlock() }
-        return allBatches.isEmpty ? nil : allBatches
-    }
+    // Last batch sent (used by tests that check a single-batch payload)
+    var capturedData: Any? { allBatches.isEmpty ? nil : allBatches }
 
     // Total events accumulated across all requests
-    var totalEventCount: Int {
-        lock.lock()
-        defer { lock.unlock() }
-        return allBatches.count
-    }
+    var totalEventCount: Int { allBatches.count }
 
     func sendRequest(_ method: OptimoveSDK.KSHttpMethod, toPath path: String, data: Any?, onSuccess: @escaping OptimoveSDK.KSHttpSuccessBlock, onFailure: @escaping OptimoveSDK.KSHttpFailureBlock) {
         if let batch = data as? [[String: Any?]] {
-            lock.lock()
             allBatches.append(contentsOf: batch)
-            lock.unlock()
         }
         onSuccess(nil, nil)
     }
-
+    
     func invalidateSessionCancellingTasks(_ cancel: Bool) {
         return
     }
@@ -225,37 +157,19 @@ class MockKSHttpClient: KSHttpClient {
 }
 
 class MockKSHttpClientSingleFailure: KSHttpClient {
-    private let lock = NSLock()
-    private var _capturedData: Any?
-    private var failed = false
-
-    // Called once the first, deliberately failed, send has been reported back.
-    var onFailureDelivered: (() -> Void)?
-
-    var capturedData: Any? {
-        lock.lock()
-        defer { lock.unlock() }
-        return _capturedData
-    }
-
+    var capturedData: Any?
+    var failed = false
+    
     func sendRequest(_ method: OptimoveSDK.KSHttpMethod, toPath path: String, data: Any?, onSuccess: @escaping OptimoveSDK.KSHttpSuccessBlock, onFailure: @escaping OptimoveSDK.KSHttpFailureBlock) {
-        lock.lock()
-        let alreadyFailed = failed
-        if !alreadyFailed {
+        if !failed {
+            onFailure(nil, NSError(domain: "domain", code: 404), nil)
             failed = true
         } else {
-            _capturedData = data
-        }
-        lock.unlock()
-
-        if !alreadyFailed {
-            onFailure(nil, NSError(domain: "domain", code: 404), nil)
-            onFailureDelivered?()
-        } else {
+            capturedData = data
             onSuccess(nil, nil)
         }
     }
-
+    
     func invalidateSessionCancellingTasks(_ cancel: Bool) {
         return
     }

--- a/OptimoveSDK/Tests/Sources/Optimobile/AnalyticsHelperTests.swift
+++ b/OptimoveSDK/Tests/Sources/Optimobile/AnalyticsHelperTests.swift
@@ -10,11 +10,11 @@ import XCTest
 import OptimoveTest
 
 class AnalyticsHelperTests: XCTestCase {
-    
+
     var mockHttpClient: MockKSHttpClient!
     var analyticsHelper: AnalyticsHelper!
     var longTimeoutInSeconds = 10.0
-    
+
     override func setUp() {
         super.setUp()
         clearAnalyticsStore()
@@ -30,126 +30,161 @@ class AnalyticsHelperTests: XCTestCase {
             try? FileManager.default.removeItem(at: url)
         }
     }
-    
+
     override func tearDown()
     {
         analyticsHelper = nil
         mockHttpClient = nil
         super.tearDown()
     }
-    
+
+    // A flush completion can outlive waitForExpectations, and tearDown then sets
+    // mockHttpClient and analyticsHelper to nil. Reading them through self from
+    // inside a completion crashes the whole test binary on the implicit unwrap,
+    // which shows up as an unrelated test failing later in the run. Capture what
+    // the completion needs before tracking, so it holds its own strong reference.
+
     func test_number_of_sent_events_same_as_tracked() {
+        let helper = analyticsHelper!
+        let mock = mockHttpClient!
         let numberOfEvents = 4
         let numberOfEventsExpectation = expectation(description: "Number of events wasnt \(numberOfEvents)")
-        
+
         for i in 1...numberOfEvents - 1 {
-            analyticsHelper.trackEvent(eventType: "immediate_event\(i)", properties: nil, immediateFlush: true)
+            helper.trackEvent(eventType: "immediate_event\(i)", properties: nil, immediateFlush: true)
         }
-        
-        self.analyticsHelper.trackEvent(eventType: "immediate_event_last", atTime: Date(), properties: nil, immediateFlush: true) {_ in
-            if let data = self.mockHttpClient.capturedData as? [[String: Any?]], data.count == numberOfEvents {
+
+        helper.trackEvent(eventType: "immediate_event_last", atTime: Date(), properties: nil, immediateFlush: true) {_ in
+            if let data = mock.capturedData as? [[String: Any?]], data.count == numberOfEvents {
                 numberOfEventsExpectation.fulfill()
             }
         }
-        
-        waitForExpectations(timeout: longTimeoutInSeconds, handler: nil)
+
+        wait(for: [numberOfEventsExpectation], timeout: longTimeoutInSeconds)
     }
-    
+
     func test_number_of_sent_events_with_delays_same_as_tracked() {
+        let helper = analyticsHelper!
+        let mock = mockHttpClient!
         let numberOfEvents = 4
-        let numberOfEventsExpectation = expectation(description: "Number of events wasnt \(numberOfEvents)")
-        
-        analyticsHelper.trackEvent(eventType: "immediate_event_first", properties: nil, immediateFlush: true)
-        
-        DispatchQueue.global().asyncAfter(deadline: .now() + 2) {
-            for i in 1...numberOfEvents - 1 {
-                self.analyticsHelper.trackEvent(eventType: "immediate_event\(i)", properties: nil, immediateFlush: true)
-            }
-            
-            self.analyticsHelper.trackEvent(eventType: "immediate_event_last", atTime: Date(), properties: nil, immediateFlush: true) {_ in
-                // +1 for immediate_event_first tracked before the delay
-                let count = self.mockHttpClient.totalEventCount
-            
-                if self.mockHttpClient.totalEventCount == numberOfEvents + 1 {
-                    numberOfEventsExpectation.fulfill()
-                }
+
+        // The point of this test is that events tracked in a later, separate flush
+        // are still all delivered. Waiting for the first flush to report completion
+        // establishes that separation directly. A sleep only made it likely, and
+        // spent 2 of the 10 second budget doing nothing, which is what tipped this
+        // test into timing out on a loaded CI runner.
+        let firstEventFlushed = expectation(description: "First event was flushed")
+        helper.trackEvent(eventType: "immediate_event_first", atTime: Date(), properties: nil, immediateFlush: true) {_ in
+            firstEventFlushed.fulfill()
+        }
+        wait(for: [firstEventFlushed], timeout: longTimeoutInSeconds)
+
+        let numberOfEventsExpectation = expectation(description: "Number of events wasnt \(numberOfEvents + 1)")
+
+        for i in 1...numberOfEvents - 1 {
+            helper.trackEvent(eventType: "immediate_event\(i)", properties: nil, immediateFlush: true)
+        }
+
+        helper.trackEvent(eventType: "immediate_event_last", atTime: Date(), properties: nil, immediateFlush: true) {_ in
+            // +1 for immediate_event_first tracked before the first flush
+            if mock.totalEventCount == numberOfEvents + 1 {
+                numberOfEventsExpectation.fulfill()
             }
         }
-        
-        waitForExpectations(timeout: longTimeoutInSeconds, handler: nil)
+
+        wait(for: [numberOfEventsExpectation], timeout: longTimeoutInSeconds)
     }
-    
+
     func test_number_of_sent_events_from_background_threads_same_as_tracked() {
+        let helper = analyticsHelper!
+        let mock = mockHttpClient!
         let numberOfEvents = 4
         let numberOfEventsExpectation = expectation(description: "Number of events wasnt \(numberOfEvents)")
-    
-        
+
         for i in 1...numberOfEvents - 1 {
             DispatchQueue.global().async {
-                self.analyticsHelper.trackEvent(eventType: "immediate_event\(i)", properties: nil, immediateFlush: true)
+                helper.trackEvent(eventType: "immediate_event\(i)", properties: nil, immediateFlush: true)
             }
         }
-        
-        analyticsHelper.trackEvent(eventType: "immediate_event_last", atTime: Date(), properties: nil, immediateFlush: true) {_ in
-            if let data = self.mockHttpClient.capturedData as? [[String: Any?]], data.count == numberOfEvents {
+
+        helper.trackEvent(eventType: "immediate_event_last", atTime: Date(), properties: nil, immediateFlush: true) {_ in
+            if let data = mock.capturedData as? [[String: Any?]], data.count == numberOfEvents {
                 numberOfEventsExpectation.fulfill()
             }
         }
-        
-        waitForExpectations(timeout: longTimeoutInSeconds, handler: nil)
+
+        wait(for: [numberOfEventsExpectation], timeout: longTimeoutInSeconds)
     }
-    
+
     func test_immediate_event_should_grab_nonimmediate() {
+        let helper = analyticsHelper!
+        let mock = mockHttpClient!
         let nonImmediateSentExpectation = expectation(description: "Non immediate wasn't sent with immediate")
-    
-        
-        analyticsHelper.trackEvent(eventType: "regular_event", properties: nil, immediateFlush: false)
-        analyticsHelper.trackEvent(eventType: "immediate_event", atTime: Date(), properties: nil, immediateFlush: true) {_ in
-            if let data = self.mockHttpClient.capturedData as? [[String: Any?]], data.count == 2 {
+
+        helper.trackEvent(eventType: "regular_event", properties: nil, immediateFlush: false)
+        helper.trackEvent(eventType: "immediate_event", atTime: Date(), properties: nil, immediateFlush: true) {_ in
+            if let data = mock.capturedData as? [[String: Any?]], data.count == 2 {
                 nonImmediateSentExpectation.fulfill()
             }
         }
-        
-        waitForExpectations(timeout: longTimeoutInSeconds, handler: nil)
+
+        wait(for: [nonImmediateSentExpectation], timeout: longTimeoutInSeconds)
     }
-    
+
     func test_failed_network_event_should_be_picked_up_by_subsequent() {
         let mockKSHttpClientSingleFailure = MockKSHttpClientSingleFailure()
         let analyticsHelper = AnalyticsHelper(httpClient: mockKSHttpClientSingleFailure)
-        
-        let failedEventExpectation = expectation(description: "Failed event wasn't sent on next dispatch")
+
+        // Wait for the send to actually fail instead of sleeping and assuming it
+        // has, so the second event is guaranteed to be the subsequent dispatch.
+        let firstSendFailed = expectation(description: "First send wasn't failed")
+        mockKSHttpClientSingleFailure.onFailureDelivered = { firstSendFailed.fulfill() }
 
         analyticsHelper.trackEvent(eventType: "immeditate_event", properties: nil, immediateFlush: true)
-        
-        DispatchQueue.global().asyncAfter(deadline: .now() + 2) {
-            analyticsHelper.trackEvent(eventType: "immediate_event_second", atTime: Date(), properties: nil, immediateFlush: true) {_ in
-                if let data = mockKSHttpClientSingleFailure.capturedData as? [[String: Any?]], data.count == 2 {
-                    failedEventExpectation.fulfill()
-                }
+        wait(for: [firstSendFailed], timeout: longTimeoutInSeconds)
+
+        let failedEventExpectation = expectation(description: "Failed event wasn't sent on next dispatch")
+
+        analyticsHelper.trackEvent(eventType: "immediate_event_second", atTime: Date(), properties: nil, immediateFlush: true) {_ in
+            if let data = mockKSHttpClientSingleFailure.capturedData as? [[String: Any?]], data.count == 2 {
+                failedEventExpectation.fulfill()
             }
         }
-        
-        waitForExpectations(timeout: longTimeoutInSeconds, handler: nil)
+
+        wait(for: [failedEventExpectation], timeout: longTimeoutInSeconds)
     }
-    
+
 }
 
 class MockKSHttpClient: KSHttpClient {
+    // Written on whichever queue AnalyticsHelper flushes from and read from test
+    // completions, so every access is behind the lock.
+    private let lock = NSLock()
     private var allBatches: [[String: Any?]] = []
 
     // Last batch sent (used by tests that check a single-batch payload)
-    var capturedData: Any? { allBatches.isEmpty ? nil : allBatches }
+    var capturedData: Any? {
+        lock.lock()
+        defer { lock.unlock() }
+        return allBatches.isEmpty ? nil : allBatches
+    }
 
     // Total events accumulated across all requests
-    var totalEventCount: Int { allBatches.count }
+    var totalEventCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return allBatches.count
+    }
 
     func sendRequest(_ method: OptimoveSDK.KSHttpMethod, toPath path: String, data: Any?, onSuccess: @escaping OptimoveSDK.KSHttpSuccessBlock, onFailure: @escaping OptimoveSDK.KSHttpFailureBlock) {
         if let batch = data as? [[String: Any?]] {
+            lock.lock()
             allBatches.append(contentsOf: batch)
+            lock.unlock()
         }
         onSuccess(nil, nil)
     }
-    
+
     func invalidateSessionCancellingTasks(_ cancel: Bool) {
         return
     }
@@ -157,19 +192,37 @@ class MockKSHttpClient: KSHttpClient {
 }
 
 class MockKSHttpClientSingleFailure: KSHttpClient {
-    var capturedData: Any?
-    var failed = false
-    
+    private let lock = NSLock()
+    private var _capturedData: Any?
+    private var failed = false
+
+    // Called once the first, deliberately failed, send has been reported back.
+    var onFailureDelivered: (() -> Void)?
+
+    var capturedData: Any? {
+        lock.lock()
+        defer { lock.unlock() }
+        return _capturedData
+    }
+
     func sendRequest(_ method: OptimoveSDK.KSHttpMethod, toPath path: String, data: Any?, onSuccess: @escaping OptimoveSDK.KSHttpSuccessBlock, onFailure: @escaping OptimoveSDK.KSHttpFailureBlock) {
-        if !failed {
-            onFailure(nil, NSError(domain: "domain", code: 404), nil)
+        lock.lock()
+        let alreadyFailed = failed
+        if !alreadyFailed {
             failed = true
         } else {
-            capturedData = data
+            _capturedData = data
+        }
+        lock.unlock()
+
+        if !alreadyFailed {
+            onFailure(nil, NSError(domain: "domain", code: 404), nil)
+            onFailureDelivered?()
+        } else {
             onSuccess(nil, nil)
         }
     }
-    
+
     func invalidateSessionCancellingTasks(_ cancel: Bool) {
         return
     }

--- a/OptimoveSDK/Tests/Sources/Optimobile/AnalyticsHelperTests.swift
+++ b/OptimoveSDK/Tests/Sources/Optimobile/AnalyticsHelperTests.swift
@@ -118,13 +118,27 @@ class AnalyticsHelperTests: XCTestCase {
         let helper = analyticsHelper!
         let mock = mockHttpClient!
         let numberOfEvents = 4
-        let numberOfEventsExpectation = expectation(description: "Number of events wasnt \(numberOfEvents)")
+
+        // Nothing ordered the background blocks before the final event, so if they
+        // had not been scheduled yet the final flush completed against a smaller
+        // store. The completion only runs once, so it never re-checked and the test
+        // sat out its whole timeout. Wait for the background events to be flushed
+        // before tracking the last one; they are still issued concurrently, which is
+        // what this test is about.
+        let backgroundEventsFlushed = expectation(description: "Background events weren't flushed")
+        backgroundEventsFlushed.expectedFulfillmentCount = numberOfEvents - 1
 
         for i in 1...numberOfEvents - 1 {
             DispatchQueue.global().async {
-                helper.trackEvent(eventType: "immediate_event\(i)", properties: nil, immediateFlush: true)
+                helper.trackEvent(eventType: "immediate_event\(i)", atTime: Date(), properties: nil, immediateFlush: true) {_ in
+                    backgroundEventsFlushed.fulfill()
+                }
             }
         }
+
+        wait(for: [backgroundEventsFlushed], timeout: longTimeoutInSeconds)
+
+        let numberOfEventsExpectation = expectation(description: "Number of events wasnt \(numberOfEvents)")
 
         helper.trackEvent(eventType: "immediate_event_last", atTime: Date(), properties: nil, immediateFlush: true) {_ in
             if let data = mock.capturedData as? [[String: Any?]], data.count == numberOfEvents {
@@ -181,7 +195,7 @@ class MockKSHttpClient: KSHttpClient {
     private let lock = NSLock()
     private var allBatches: [[String: Any?]] = []
 
-    // Last batch sent (used by tests that check a single-batch payload)
+    // Every event delivered so far, across all requests, in delivery order
     var capturedData: Any? {
         lock.lock()
         defer { lock.unlock() }

--- a/OptimoveSDK/Tests/Sources/Optimobile/SessionHelperTests.swift
+++ b/OptimoveSDK/Tests/Sources/Optimobile/SessionHelperTests.swift
@@ -43,7 +43,10 @@ final class SessionHelperTests: XCTestCase {
         releaseTracking.signal()
     }
 
-    func test_sessionDidEnd_invokesTrackingCompletionAsynchronously() {
+    // The mock is what defers here, so this only covers that sessionDidEnd routes
+    // through trackBackground and its completion runs. Asynchrony of the SDK's own
+    // call is covered by the test above.
+    func test_sessionDidEnd_invokesTrackingCompletion() {
         let completionFired = expectation(description: "onSyncComplete fired")
 
         let asyncMock: (Date, @escaping SyncCompletedBlock) -> Void = { _, done in

--- a/OptimoveSDK/Tests/Sources/Optimobile/SessionHelperTests.swift
+++ b/OptimoveSDK/Tests/Sources/Optimobile/SessionHelperTests.swift
@@ -3,41 +3,61 @@ import XCTest
 
 final class SessionHelperTests: XCTestCase {
 
-    func test_sessionDidEnd_returnsImmediately_underSlowNetwork() {
-        let delay: TimeInterval = 2.5
-        let delayedMock: (Date, @escaping SyncCompletedBlock) -> Void = { _, done in
-            DispatchQueue.global().asyncAfter(deadline: .now() + delay) {
+    private let timeoutInSeconds = 10.0
+
+    // Both tests previously encoded "does not block" as wall-clock measurements:
+    // an elapsed-time assertion of under 100ms, and a 2 second sleep inside a 3
+    // second timeout. Neither survives a loaded CI runner, where scheduling delay
+    // alone can exceed the margin even though the behaviour is correct. They now
+    // assert ordering instead, so the timeouts are only a backstop against a real
+    // hang rather than the thing being measured.
+
+    func test_sessionDidEnd_doesNotWaitForTrackingToComplete() {
+        // Held until the test releases it, so the tracking completion cannot run
+        // before sessionDidEnd has returned.
+        let releaseTracking = DispatchSemaphore(value: 0)
+        let trackingInvoked = expectation(description: "trackBackground was invoked")
+        let sessionDidEndReturned = expectation(description: "sessionDidEnd returned")
+
+        let blockingMock: (Date, @escaping SyncCompletedBlock) -> Void = { _, done in
+            trackingInvoked.fulfill()
+            DispatchQueue.global().async {
+                releaseTracking.wait()
                 done(nil)
             }
         }
 
-        let helper = SessionHelper(sessionIdleTimeout: 1, trackBackground: delayedMock)
+        let helper = SessionHelper(sessionIdleTimeout: 1, trackBackground: blockingMock)
         helper.setBecameInactiveAtForTest(Date())
 
-        let start = CFAbsoluteTimeGetCurrent()
-        helper.sessionDidEnd()
-        let elapsedMs = (CFAbsoluteTimeGetCurrent() - start) * 1000
+        DispatchQueue.global().async {
+            helper.sessionDidEnd()
+            sessionDidEndReturned.fulfill()
+        }
 
-        XCTAssertLessThan(elapsedMs, 100, "sessionDidEnd should not block the caller")
+        // sessionDidEnd has to return while tracking is still outstanding. If it
+        // waited for done(nil), it would block on releaseTracking, which is only
+        // signalled below, and this wait would time out.
+        wait(for: [trackingInvoked, sessionDidEndReturned], timeout: timeoutInSeconds)
+
+        releaseTracking.signal()
     }
 
-    func test_sessionDidEnd_completionFires_async() {
-        let completionExpectation = expectation(description: "onSyncComplete fired")
-        let delay: TimeInterval = 2.0
-        let delayedMock: (Date, @escaping SyncCompletedBlock) -> Void = { _, done in
-            DispatchQueue.global().asyncAfter(deadline: .now() + delay) {
+    func test_sessionDidEnd_invokesTrackingCompletionAsynchronously() {
+        let completionFired = expectation(description: "onSyncComplete fired")
+
+        let asyncMock: (Date, @escaping SyncCompletedBlock) -> Void = { _, done in
+            DispatchQueue.global().async {
                 done(nil)
-                completionExpectation.fulfill()
+                completionFired.fulfill()
             }
         }
 
-        let helper = SessionHelper(sessionIdleTimeout: 1, trackBackground: delayedMock)
+        let helper = SessionHelper(sessionIdleTimeout: 1, trackBackground: asyncMock)
         helper.setBecameInactiveAtForTest(Date())
 
         helper.sessionDidEnd()
 
-        waitForExpectations(timeout: delay + 1.0)
+        wait(for: [completionFired], timeout: timeoutInSeconds)
     }
 }
-
-


### PR DESCRIPTION
[AB#292773](https://mobius.visualstudio.com/7b12c5d6-c2cb-4957-9a09-46dfabf0bd18/_workitems/edit/292773)

### Description of Changes

`SessionHelperTests` asserted the wrong thing. `sessionDidEnd()` must return without waiting for
the background flush it kicks off — that is the whole point of the change in 6.2.6, "remove
semaphore wait in session end to avoid QoS inversion during background flush" — but the test only
checked that the tracking completion eventually ran. It would have passed just as happily if
`sessionDidEnd()` had gone back to blocking.

The test now asserts the ordering directly. Tracking blocks on a semaphore the test releases only
after `sessionDidEnd()` has returned, so a version that waited for tracking could not get past it:

```swift
let releaseTracking = DispatchSemaphore(value: 0)
let trackingInvoked = expectation(description: "trackBackground was invoked")
let sessionDidEndReturned = expectation(description: "sessionDidEnd returned")

let blockingMock: (Date, @escaping SyncCompletedBlock) -> Void = { _, done in
    trackingInvoked.fulfill()
    DispatchQueue.global().async { releaseTracking.wait(); done(nil) }
}
...
DispatchQueue.global().async { helper.sessionDidEnd(); sessionDidEndReturned.fulfill() }
wait(for: [trackingInvoked, sessionDidEndReturned], timeout: timeoutInSeconds)
releaseTracking.signal()
```

The old test is kept as `test_sessionDidEnd_invokesTrackingCompletion` — renamed to say what it
actually checks, since "does not wait" was never what it measured.

### Scope was narrowed — the AnalyticsHelper half is gone

This PR originally also reworked `AnalyticsHelperTests`. **#134 fixes that flake better and this
branch now stays out of its way.**

Both of us independently found the same root cause: the simulator does not enforce entitlements, so
`containerURL(forSecurityApplicationGroupIdentifier:)` resolves for any group identifier and
`AnalyticsHelper` silently opens the shared-container database — while the test helper cleared the
Documents one, which was never the database in use. So the tests never had isolation and events
accumulated across the class.

Where the fixes differ:

| | this PR (dropped) | #134 (kept) |
|---|---|---|
| Approach | clear the shared database in both locations | `storeUrlOverride`: a fresh store per test |
| Isolation | only as good as the deletion is complete | real, by construction |
| Production code | untouched | a test-only hook on the initialiser |

Per-test stores are the right answer — the weakness I flagged in my own version was exactly that it
still rested on deleting a shared file. Keeping both would also have conflicted: they touch the same
`setUp`, `tearDown` and count assertions. `AnalyticsHelperTests` is therefore back to master's
version here, and the remaining timing work on it lives in **#150**, on top of #134.

### Verification

Full suite: **75 tests, 0 failures.**

Mutation-checked — restoring the semaphore wait in `SessionHelper.sessionDidEnd()` fails
`test_sessionDidEnd_doesNotWaitForTrackingToComplete` and leaves
`test_sessionDidEnd_invokesTrackingCompletion` passing, which is the split the rename describes.

Both tests run in **0.003s**.

### One thing this does not claim

I could not reproduce the CI flake locally, so I am not claiming a measured reduction anywhere.
Running the suite 8 times under full 11-core CPU load on unfixed `master` passed 8/8 — the run
slowed from 2.8s to 31s, so the load was real, but the flake needs something about the
GitHub-hosted runner. The argument here is about what the tests assert, not about flake rates.

### Breaking Changes

-   None

Test-only. No version bump.

### Release Checklist

- [x] Detail any breaking changes — none, tests only
- [ ] `pod lib lint` — n/a, no shipped code changed
- [ ] Wiki — n/a

### Integration tests

n/a — no shipped code changed.
