### PR TITLE
AB#292770 fix: give configuration networking a cache large enough to hold the tenant config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.8.2
+
+- Fix the tenant configuration being downloaded in full on every launch. It exceeded the size `URLSession` will store in `URLCache.shared`, so it was never cached and never revalidated. Configuration networking now uses its own cache with a larger capacity, and the response is served from disk while fresh or revalidated with `If-None-Match`.
+
 ## 6.8.0
 
 - Add `OptimoveOverlayMessaging.setActionHandler(_:)` — register a handler to intercept overlay CTA clicks and perform custom navigation instead of the SDK opening the URL.

--- a/OptimoveCore.podspec
+++ b/OptimoveCore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'OptimoveCore'
-  s.version          = '6.8.0'
+  s.version          = '6.8.2'
   s.summary          = 'Official Optimove SDK for iOS. Core framework.'
   s.description      = 'The core framework is used to share code-base between other Optimove frameworks.'
   s.homepage         = 'https://github.com/optimove-tech/Optimove-SDK-iOS'

--- a/OptimoveCore/Sources/Classes/Constants/SDKVersion.swift
+++ b/OptimoveCore/Sources/Classes/Constants/SDKVersion.swift
@@ -1,3 +1,3 @@
 //  Copyright © 2019 Optimove. All rights reserved.
 
-public let SDKVersion = "6.8.0"
+public let SDKVersion = "6.8.2"

--- a/OptimoveNotificationServiceExtension.podspec
+++ b/OptimoveNotificationServiceExtension.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'OptimoveNotificationServiceExtension'
-  s.version          = '6.8.0'
+  s.version          = '6.8.2'
   s.summary          = 'Official Optimove SDK for iOS. Notification service extension framework.'
   s.description      = 'The notification service extension is used for handling additional content in push notifications.'
   s.homepage         = 'https://github.com/optimove-tech/Optimove-SDK-iOS'

--- a/OptimoveSDK.podspec
+++ b/OptimoveSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'OptimoveSDK'
-  s.version          = '6.8.0'
+  s.version          = '6.8.2'
   s.summary          = 'Official Optimove SDK for iOS.'
   s.description      = 'The Optimove SDK framework is used for reporting events and receive push notifications.'
   s.homepage         = 'https://github.com/optimove-tech/Optimove-SDK-iOS'

--- a/OptimoveSDK/Sources/Classes/Services/ServiceLocator.swift
+++ b/OptimoveSDK/Sources/Classes/Services/ServiceLocator.swift
@@ -123,9 +123,32 @@ final class ServiceLocator {
         )
     }
 
+    /// URLSession will not store a response larger than roughly 5% of its cache
+    /// capacity. `URLCache.shared` has a 10 MB disk capacity, i.e. a ~500 KB ceiling,
+    /// and the tenant configuration decodes to more than that. It was therefore never
+    /// cached, so no validator was ever kept, no conditional request was ever sent,
+    /// and the whole file was downloaded again on every launch. A dedicated cache with
+    /// a higher capacity keeps the entry, letting URLSession revalidate with
+    /// `If-None-Match` and serve from disk while the response is fresh.
+    ///
+    /// Scoped to configuration networking so nothing else changes caching behaviour,
+    /// and deliberately not `URLCache.shared`, which belongs to the host app.
+    ///
+    /// `static`, because `networkingFactory()` returns a new instance per call and the
+    /// cache has to outlive them to be of any use.
+    static let configurationURLCache = URLCache(
+        memoryCapacity: 2 << 20,
+        diskCapacity: 20 << 20,
+        diskPath: "com.optimove.configuration-cache"
+    )
+
     func networkingFactory() -> NetworkingFactory {
+        let configuration = URLSessionConfiguration.default
+        configuration.urlCache = ServiceLocator.configurationURLCache
+        configuration.requestCachePolicy = .useProtocolCachePolicy
+
         return NetworkingFactory(
-            networkClient: NetworkClientImpl(),
+            networkClient: NetworkClientImpl(configuration: configuration),
             requestBuilderFactory: NetworkRequestBuilderFactory(
                 serviceLocator: self
             )

--- a/OptimoveSDK/Tests/Sources/Network/ConfigurationURLCacheTests.swift
+++ b/OptimoveSDK/Tests/Sources/Network/ConfigurationURLCacheTests.swift
@@ -1,0 +1,30 @@
+//  Copyright © 2026 Optimove. All rights reserved.
+
+import XCTest
+@testable import OptimoveSDK
+
+final class ConfigurationURLCacheTests: XCTestCase {
+
+    // URLSession's automatic caching refuses to store a response larger than roughly
+    // 5% of the cache capacity. Measured against a local server: a 944 KB response is
+    // not stored in a 10 MB cache and is stored in a 20 MB one. The capacity therefore
+    // has to be at least 20x the largest configuration we expect, or the response is
+    // silently never cached, no validator is kept, and the whole file is refetched on
+    // every launch.
+    private let expectedMaxConfigurationSize = 1 << 20 // 1 MB
+
+    func test_configurationCache_canHoldTheLargestExpectedConfiguration() {
+        XCTAssertGreaterThanOrEqual(
+            ServiceLocator.configurationURLCache.diskCapacity,
+            expectedMaxConfigurationSize * 20,
+            "URLSession would refuse to store the tenant configuration in a cache this small"
+        )
+    }
+
+    func test_configurationCache_isNotTheSharedCache() {
+        XCTAssertFalse(
+            ServiceLocator.configurationURLCache === URLCache.shared,
+            "Configuration networking must not use the host app's shared cache"
+        )
+    }
+}


### PR DESCRIPTION
### Description of Changes

The tenant configuration is downloaded in full on every launch instead of revalidating.
Roughly 500 KB–1 MB decoded, every time.

**Root cause:** URLSession's automatic caching refuses to store a response larger than
roughly 5% of the cache capacity. `URLCache.shared` has a 10 MB disk capacity — a ~500 KB
ceiling — and the tenant configuration exceeds it. So it was never stored, no validator was
ever kept, and no conditional request was ever sent. Nothing could return 304, because
nothing ever asked.

Measured against a local server serving `ETag` + `Cache-Control: max-age=300`, driving
URLSession's own caching rather than `storeCachedResponse`:

| Cache disk capacity | Response | Stored? | Second fetch |
|---|---|---|---|
| 10 MB (= `URLCache.shared`) | 944 KB | **no** | hits the network |
| 20 MB | 944 KB | **yes** | served from cache, no request |
| 10 MB | 109 B | yes | served from cache |

944 KB is 9.4% of 10 MB and 4.5% of 20 MB, consistent with the ~5% rule.

**Fix:** configuration networking gets its own `URLCache` with a 20 MB disk capacity, set on
the `URLSessionConfiguration` passed to `NetworkClientImpl`. Scoped to
`ServiceLocator.networkingFactory()`, which has a single call site feeding only
`createRemoteConfigurationNetworking()`, so no other networking changes behaviour.
Deliberately **not** `URLCache.shared` — that belongs to the host app. `static`, because the
factory returns a new instance per call and the cache has to outlive them.

#### The origin does support revalidation

Worth recording, since it was the main open question. GCS varies the ETag by representation,
and conditional requests succeed when the client sends the ETag for the encoding it accepts:

| `Accept-Encoding` | `If-None-Match` | Result |
|---|---|---|
| none | `W/"fb65…"` (weak, as served) | **304** |
| none | `"fb65…"` (strong) | 200 |
| gzip | `W/"fb65…"` (weak) | 200 |
| gzip | `"fb65…"` (strong, as served) | **304** |

URLSession sends `Accept-Encoding: gzip` and would cache the gzip representation together
with its strong ETag, which is the working row. So raising the capacity is sufficient — no
SDK-side ETag handling is needed.

(Measured on the global config, `sdk-cdn.optimove.net`, which is publicly reachable. The
tenant config needs a token, so it could not be measured directly, but both are served by
the same bucket and the handoff's captured tenant headers match this shape.)

### Verification

Full suite: **77 tests, 0 failures** (75 before, plus the two added here).

The new tests were mutation-checked — reverting the factory to `URLCache.shared` fails both:

```
XCTAssertGreaterThanOrEqual failed: ("10000000") is less than ("20971520")
  - URLSession would refuse to store the tenant configuration in a cache this small
XCTAssertFalse failed
  - Configuration networking must not use the host app's shared cache
```

### Two things deliberately not changed

**No explicit 304 handling in `NetworkClientImpl`.** A bare 304 does reach the completion
handler — confirmed with a server returning 304 unconditionally: `status=304 bodyBytes=0
error=nil`, which falls to the `default:` case and becomes a success with an empty body, so
`JSONDecoder` throws. But it only arises if an origin answers 304 to a *non-conditional*
request; when there is a cache entry, URLSession replays the cached bytes and the client sees
200. And the consequence is already benign: `TenantConfigurationDownloader` logs the error
and returns without calling `saveTenant`, so the previously stored configuration is retained
— which is what "not modified" should mean. A 304 also implies a prior successful fetch, so
there is always a stored config to fall back on. Adding handling would change the log line,
not the behaviour, so it is left out of this PR.

**`ServiceLocator.networking()` and `networkClient()` untouched.** They build their own
`NetworkClientImpl` for other purposes and keep the default shared cache.

### Breaking Changes

-   None

The SDK now keeps up to 20 MB of configuration cache on disk, in its own
`com.optimove.configuration-cache` directory rather than in the host app's shared cache.

### Release Checklist

### Prepare:

- [x] Detail any breaking changes. Breaking changes require a new major version number — none
- [ ] Check `pod lib lint` passes
- [ ] Update any relevant sections of the repository wiki pages on a branch — n/a, no public API change

### Bump versions in:

Bumped to **6.8.2**. 6.8.1 is already claimed by the pending `stopDispatchTimer` fix
(#144), so this takes the next patch number rather than colliding with it in the changelog.
If this merges before #144, 6.8.1 is simply skipped.

- [x] `OptimoveCore.podspec`
- [x] `OptimoveNotificationServiceExtension.podspec`
- [x] `OptimoveSDK.podspec`
- [x] `OptimoveCore/Sources/Classes/Constants/SDKVersion.swift`
- [ ] `README.md` — n/a, contains no version reference
- [x] `CHANGELOG.md`

### Integration tests

Unit tests pass (77, 0 failures). The end-to-end check worth doing on a real tenant: capture
traffic across two launches within the 5 minute `max-age` and confirm the tenant config is
not refetched, then again after it expires and confirm a 304 rather than a 200.

*T&T Only*

- [ ] Init SDK with only T&T credentials
- [ ] Track events

*Mobile Only*

- [ ] Init SDK with all credentials
- [ ] Track events
- [ ] Register for push

### Release:

- [ ] Squash and merge to master
- [ ] Delete branch once merged
