### PR TITLE
AB#292768 fix(push): chain and harden the UNUserNotificationCenter delegate install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 6.8.3
+
+- Harden installation of the `UNUserNotificationCenter` delegate. Notifications that are not Optimove's are still forwarded to the delegate the host app had installed, and that rule is now covered by tests; re-installing over our own delegate no longer nests the chain; and a delegate the host app installs *after* the SDK, which silently takes push handling away from the SDK, is now reported in the log.
+- Fix the push swizzling crashing when the SDK is initialized before `UIApplication`'s delegate is set, and install it on the main thread rather than whichever thread initialized the SDK.
+
 ## 6.8.0
 
 - Add `OptimoveOverlayMessaging.setActionHandler(_:)` — register a handler to intercept overlay CTA clicks and perform custom navigation instead of the SDK opening the URL.

--- a/OptimoveCore.podspec
+++ b/OptimoveCore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'OptimoveCore'
-  s.version          = '6.8.0'
+  s.version          = '6.8.3'
   s.summary          = 'Official Optimove SDK for iOS. Core framework.'
   s.description      = 'The core framework is used to share code-base between other Optimove frameworks.'
   s.homepage         = 'https://github.com/optimove-tech/Optimove-SDK-iOS'

--- a/OptimoveCore/Sources/Classes/Constants/SDKVersion.swift
+++ b/OptimoveCore/Sources/Classes/Constants/SDKVersion.swift
@@ -1,3 +1,3 @@
 //  Copyright © 2019 Optimove. All rights reserved.
 
-public let SDKVersion = "6.8.0"
+public let SDKVersion = "6.8.3"

--- a/OptimoveNotificationServiceExtension.podspec
+++ b/OptimoveNotificationServiceExtension.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'OptimoveNotificationServiceExtension'
-  s.version          = '6.8.0'
+  s.version          = '6.8.3'
   s.summary          = 'Official Optimove SDK for iOS. Notification service extension framework.'
   s.description      = 'The notification service extension is used for handling additional content in push notifications.'
   s.homepage         = 'https://github.com/optimove-tech/Optimove-SDK-iOS'

--- a/OptimoveSDK.podspec
+++ b/OptimoveSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'OptimoveSDK'
-  s.version          = '6.8.0'
+  s.version          = '6.8.3'
   s.summary          = 'Official Optimove SDK for iOS.'
   s.description      = 'The Optimove SDK framework is used for reporting events and receive push notifications.'
   s.homepage         = 'https://github.com/optimove-tech/Optimove-SDK-iOS'

--- a/OptimoveSDK/Sources/Classes/Optimobile/NotificationDelegateRouting.swift
+++ b/OptimoveSDK/Sources/Classes/Optimobile/NotificationDelegateRouting.swift
@@ -1,0 +1,64 @@
+//  Copyright © 2026 Optimove. All rights reserved.
+
+import Foundation
+import UserNotifications
+
+/// What should happen to a notification that arrives while the app is in the foreground.
+enum ForegroundNotificationRoute: Equatable {
+    /// Not one of ours, so it belongs to the delegate we replaced.
+    case forwardToExistingDelegate
+    /// One of ours, and the host app registered no foreground handler.
+    case presentWithDefaultOptions
+    /// One of ours, and the host app registered a handler to decide how to present it.
+    case invokeForegroundHandler
+}
+
+/// What should happen to the user's response to a notification.
+enum NotificationResponseRoute: Equatable {
+    /// Not one of ours, so it belongs to the delegate we replaced.
+    case forwardToExistingDelegate
+    case handleDismissal
+    case handleOpen
+}
+
+/// The routing rules of `OptimoveUserNotificationCenterDelegate`.
+///
+/// `UNUserNotificationCenter` permits exactly one delegate, so installing ours displaces
+/// whatever the host app set. Everything that is not an Optimove notification therefore has
+/// to be forwarded to the delegate we displaced — that rule is the whole reason the host
+/// app keeps working, and until now it lived inline in two protocol methods that no test
+/// can reach: `UNUserNotificationCenter.current()` raises
+/// `bundleProxyForCurrentProcess is nil` in a test bundle, and neither `UNNotification` nor
+/// `UNNotificationResponse` can be constructed. Keeping the rules here, as functions of the
+/// payload alone, is what makes them verifiable.
+enum NotificationDelegateRouting {
+    static func route(
+        willPresent notification: PushNotification,
+        hasForegroundHandler: Bool
+    ) -> ForegroundNotificationRoute {
+        guard isOurs(notification) else {
+            return .forwardToExistingDelegate
+        }
+
+        return hasForegroundHandler ? .invokeForegroundHandler : .presentWithDefaultOptions
+    }
+
+    @available(iOS 10.0, *)
+    static func route(
+        didReceive notification: PushNotification,
+        actionIdentifier: String
+    ) -> NotificationResponseRoute {
+        guard isOurs(notification) else {
+            return .forwardToExistingDelegate
+        }
+
+        return actionIdentifier == UNNotificationDismissActionIdentifier ? .handleDismissal : .handleOpen
+    }
+
+    /// A notification is ours when its payload carries an Optimove message id. Anything
+    /// else — the host app's own pushes, another SDK's pushes, local notifications — is not
+    /// ours to answer.
+    private static func isOurs(_ notification: PushNotification) -> Bool {
+        return notification.id != 0
+    }
+}

--- a/OptimoveSDK/Sources/Classes/Optimobile/Optimobile+Push.swift
+++ b/OptimoveSDK/Sources/Classes/Optimobile/Optimobile+Push.swift
@@ -376,18 +376,48 @@ class PushHelper {
     typealias kumulos_applicationDidReceiveRemoteNotificationFetchCompletionHandler = @convention(c) (_ obj: Any, _ _cmd: Selector, _ application: UIApplication, _ userInfo: [AnyHashable: Any], _ completionHandler: @escaping (UIBackgroundFetchResult) -> Void) -> Void
     typealias didReceiveBlock = @convention(block) (_ obj: Any, _ application: UIApplication, _ userInfo: [AnyHashable: Any], _ completionHandler: @escaping (UIBackgroundFetchResult) -> Void) -> Void
     
+    private var didInstall = false
+
     lazy var pushInit: Void = {
-        let delegate = UIApplication.shared.delegate!
-        
-        // Get the actual runtime class of the delegate instance to co-exist with other swizzling flows
-        let klass: AnyClass = object_getClass(delegate)!
-        
-        self.swizzleDidRegister(delegate: delegate, klass: klass)
-        self.swizzleDidFailRegister(delegate: delegate, klass: klass)
-        self.swizzleDidReceive(delegate: delegate, klass: klass)
-        self.setUserNotificationCenterDelegates()
+        // `UIApplication.shared` and its delegate are main-thread only, and the swizzling
+        // below writes the file-scope IMP globals. Confining the install to the main thread
+        // keeps both correct no matter which thread the SDK was initialized from.
+        if Thread.isMainThread {
+            self.install()
+        } else {
+            DispatchQueue.main.async {
+                self.install()
+            }
+        }
     }()
-    
+
+    private func install() {
+        guard !didInstall else {
+            // Replacing again would make `class_replaceMethod` hand back our own IMP, and
+            // the swizzled method would then call itself until the stack runs out.
+            Logger.debug("Push notification handling is already installed")
+            return
+        }
+
+        guard let delegate = UIApplication.shared.delegate else {
+            Logger.error("The application has no UIApplicationDelegate, so push notification handling could not be installed. Initialize the SDK from application(_:didFinishLaunchingWithOptions:).")
+            return
+        }
+
+        // Get the actual runtime class of the delegate instance to co-exist with other swizzling flows
+        guard let klass: AnyClass = object_getClass(delegate) else {
+            Logger.error("Could not resolve the runtime class of the UIApplicationDelegate, so push notification handling could not be installed.")
+            return
+        }
+
+        didInstall = true
+
+        swizzleDidRegister(delegate: delegate, klass: klass)
+        swizzleDidFailRegister(delegate: delegate, klass: klass)
+        swizzleDidReceive(delegate: delegate, klass: klass)
+        setUserNotificationCenterDelegate()
+    }
+
     private func swizzleDidRegister(delegate: UIApplicationDelegate, klass: AnyClass) {
         let didRegisterSelector = #selector(UIApplicationDelegate.application(_:didRegisterForRemoteNotificationsWithDeviceToken:))
         let regType = NSString(string: "v@:@@").utf8String
@@ -421,8 +451,6 @@ class PushHelper {
     }
     
     private func swizzleDidFailRegister(delegate: UIApplicationDelegate, klass: AnyClass) {
-        let klass: AnyClass = object_getClass(delegate)!
-        
         let didFailToRegisterSelector = #selector(UIApplicationDelegate.application(_:didFailToRegisterForRemoteNotificationsWithError:))
         let didFailToRegType = NSString(string: "v@:@@").utf8String
         let didFailToRegBlock: didFailToRegBlock = { (obj: Any, application: UIApplication, error: Error) in
@@ -479,15 +507,38 @@ class PushHelper {
         }
     }
     
-    private func setUserNotificationCenterDelegates(){
+    private func setUserNotificationCenterDelegate() {
         if #available(iOS 10, *) {
-            let delegate = OptimoveUserNotificationCenterDelegate()
-            
+            let center = UNUserNotificationCenter.current()
+            // Chain to whatever the host app installed, so that their notifications keep
+            // reaching them. `UNUserNotificationCenter` allows a single delegate, so this is
+            // the only way to co-exist with it.
+            let delegate = OptimoveUserNotificationCenterDelegate(existingDelegate: center.delegate)
+
+            // The center holds its delegate weakly; this is what keeps ours alive.
             Optimobile.sharedInstance.notificationCenter = delegate
-            UNUserNotificationCenter.current().delegate = delegate
+            center.delegate = delegate
+
+            warnIfReplaced(delegate)
         }
     }
-    
+
+    /// Chaining only covers a delegate the host app installed *before* the SDK. One
+    /// installed afterwards replaces ours outright and the SDK stops seeing notifications
+    /// entirely — until now without leaving a trace. Checking once the current run loop turn
+    /// has drained catches the common case, the assignment happening later in
+    /// `application(_:didFinishLaunchingWithOptions:)`.
+    @available(iOS 10, *)
+    private func warnIfReplaced(_ delegate: UNUserNotificationCenterDelegate) {
+        DispatchQueue.main.async {
+            guard UNUserNotificationCenter.current().delegate !== delegate else {
+                return
+            }
+
+            Logger.warn("UNUserNotificationCenter.current().delegate was replaced after the Optimove SDK was initialized, so the SDK will no longer be notified about push notifications. Either set your delegate before initializing the SDK, so that the SDK can forward to it, or report opens yourself with Optimove.shared.trackOpenMetric(userInfo:).")
+        }
+    }
+
     private func getForwardingImpl(target: AnyObject, originalSelector: Selector) -> IMP?{
         let selector = NSSelectorFromString("forwardingTargetForSelector:")
         if target.responds(to: selector),

--- a/OptimoveSDK/Sources/Classes/Optimobile/OptimoveUserNotificationCenterDelegate.swift
+++ b/OptimoveSDK/Sources/Classes/Optimobile/OptimoveUserNotificationCenterDelegate.swift
@@ -5,72 +5,97 @@ import UserNotifications
 
 @available(iOS 10.0, *)
 class OptimoveUserNotificationCenterDelegate: NSObject, UNUserNotificationCenterDelegate {
+    /// The delegate this one was installed over. Everything that is not an Optimove
+    /// notification is forwarded to it, so that replacing the host app's delegate does not
+    /// take their notification handling away.
     let existingDelegate: UNUserNotificationCenterDelegate?
 
-    override init() {
-        existingDelegate = UNUserNotificationCenter.current().delegate
+    /// - Parameter existingDelegate: the delegate currently installed on the notification
+    ///   center, read by the caller. Injected rather than read from
+    ///   `UNUserNotificationCenter.current()` here, because that call raises in a test
+    ///   bundle and made this class impossible to construct in a test.
+    init(existingDelegate: UNUserNotificationCenterDelegate?) {
+        if let ours = existingDelegate as? OptimoveUserNotificationCenterDelegate {
+            // Never chain to another delegate of ours. Nesting would make us handle each
+            // notification once per layer, and forward each one to the host app's delegate
+            // as many times over.
+            self.existingDelegate = ours.existingDelegate
+        } else {
+            self.existingDelegate = existingDelegate
+        }
+
+        super.init()
     }
 
     func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
         let push = PushNotification(userInfo: notification.request.content.userInfo, response: nil)
+        // Read once: `config` is replaced wholesale when a delayed configuration completes.
+        let foregroundHandler = Optimobile.sharedInstance.config.pushReceivedInForegroundHandlerBlock
 
-        if push.id == 0 {
+        switch NotificationDelegateRouting.route(willPresent: push, hasForegroundHandler: foregroundHandler != nil) {
+        case .forwardToExistingDelegate:
             chainCenter(center, willPresent: notification, with: completionHandler)
-            return
-        }
 
-        if Optimobile.sharedInstance.config.pushReceivedInForegroundHandlerBlock == nil {
+        case .presentWithDefaultOptions:
             completionHandler(.alert)
-            return
-        }
 
-        Optimobile.sharedInstance.config.pushReceivedInForegroundHandlerBlock?(push, completionHandler)
+        case .invokeForegroundHandler:
+            guard let foregroundHandler = foregroundHandler else {
+                // Unreachable: the route is derived from this very value. Present rather
+                // than leave the completion handler uncalled, which would hang the banner.
+                completionHandler(.alert)
+                return
+            }
+
+            foregroundHandler(push, completionHandler)
+        }
     }
 
     func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
         let userInfo = response.notification.request.content.userInfo
+        let push = PushNotification(userInfo: userInfo, response: response)
 
-        if userInfo["aps"] == nil {
+        switch NotificationDelegateRouting.route(didReceive: push, actionIdentifier: response.actionIdentifier) {
+        case .forwardToExistingDelegate:
             chainCenter(center, didReceive: response, with: completionHandler)
+
+        case .handleDismissal:
+            let handled = Optimobile.sharedInstance.pushHandleDismissed(withUserInfo: userInfo, response: response)
+            if handled {
+                completionHandler()
+            } else {
+                chainCenter(center, didReceive: response, with: completionHandler)
+            }
+
+        case .handleOpen:
+            let handled = Optimobile.sharedInstance.pushHandleOpen(withUserInfo: userInfo, response: response)
+            if handled {
+                completionHandler()
+            } else {
+                chainCenter(center, didReceive: response, with: completionHandler)
+            }
+        }
+    }
+
+    fileprivate func chainCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, with completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+        let selector = #selector(userNotificationCenter(_:willPresent:withCompletionHandler:))
+
+        guard let existingDelegate = existingDelegate, existingDelegate.responds(to: selector) else {
+            completionHandler(.alert)
             return
         }
 
-        if response.actionIdentifier == UNNotificationDismissActionIdentifier {
-            let handled = Optimobile.sharedInstance.pushHandleDismissed(withUserInfo: userInfo, response: response)
-            if !handled {
-                chainCenter(center, didReceive: response, with: completionHandler)
-                return
-            }
+        existingDelegate.userNotificationCenter?(center, willPresent: notification, withCompletionHandler: completionHandler)
+    }
 
+    fileprivate func chainCenter(_ center: UNUserNotificationCenter, didReceive notificationResponse: UNNotificationResponse, with completionHandler: @escaping () -> Void) {
+        let selector = #selector(userNotificationCenter(_:didReceive:withCompletionHandler:))
+
+        guard let existingDelegate = existingDelegate, existingDelegate.responds(to: selector) else {
             completionHandler()
             return
         }
 
-        let handled = Optimobile.sharedInstance.pushHandleOpen(withUserInfo: userInfo, response: response)
-
-        if !handled {
-            chainCenter(center, didReceive: response, with: completionHandler)
-            return
-        }
-
-        completionHandler()
-    }
-
-    fileprivate func chainCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, with completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
-        if existingDelegate != nil, existingDelegate?.responds(to: #selector(userNotificationCenter(_:willPresent:withCompletionHandler:))) == true {
-            self.existingDelegate?.userNotificationCenter?(center, willPresent: notification, withCompletionHandler: completionHandler)
-            return
-        }
-
-        completionHandler(.alert)
-    }
-
-    fileprivate func chainCenter(_ center: UNUserNotificationCenter, didReceive notificationResponse: UNNotificationResponse, with completionHandler: @escaping () -> Void) {
-        if existingDelegate != nil, existingDelegate?.responds(to: #selector(userNotificationCenter(_:didReceive:withCompletionHandler:))) == true {
-            self.existingDelegate?.userNotificationCenter?(center, didReceive: notificationResponse, withCompletionHandler: completionHandler)
-            return
-        }
-
-        completionHandler()
+        existingDelegate.userNotificationCenter?(center, didReceive: notificationResponse, withCompletionHandler: completionHandler)
     }
 }

--- a/OptimoveSDK/Tests/Sources/Optimobile/NotificationDelegateRoutingTests.swift
+++ b/OptimoveSDK/Tests/Sources/Optimobile/NotificationDelegateRoutingTests.swift
@@ -1,0 +1,162 @@
+//  Copyright © 2026 Optimove. All rights reserved.
+
+import UserNotifications
+import XCTest
+@testable import OptimoveSDK
+
+private class HostAppDelegate: NSObject, UNUserNotificationCenterDelegate {}
+
+/// Installing our delegate displaces the host app's, so anything that is not an Optimove
+/// notification has to be forwarded to theirs. These tests pin that rule down.
+final class NotificationDelegateRoutingTests: XCTestCase {
+    // MARK: - Payloads
+
+    /// What the Optimove push service sends. `PushNotification` reads the message id out of
+    /// `custom.a.k.message.data.id`, and a non-zero id is what marks a notification as ours.
+    private func optimoveNotification(id: Int = 42) -> PushNotification {
+        return PushNotification(userInfo: [
+            "aps": ["alert": ["title": "Title", "body": "Body"]],
+            "custom": ["a": ["k.message": ["data": ["id": id]]]],
+        ])
+    }
+
+    /// A remote notification from somewhere else — the host app's own push provider, or
+    /// another SDK. It has an `aps` payload like ours, and no Optimove message id.
+    private func foreignRemoteNotification() -> PushNotification {
+        return PushNotification(userInfo: [
+            "aps": ["alert": "Sent by someone else"],
+            "myAppsOwnKey": "value",
+        ])
+    }
+
+    /// A local notification scheduled by the host app. No `aps` payload at all.
+    private func localNotification() -> PushNotification {
+        return PushNotification(userInfo: ["myAppsOwnKey": "value"])
+    }
+
+    // MARK: - Foreground presentation
+
+    func test_foreignRemoteNotification_isForwardedToTheDelegateWeReplaced() {
+        XCTAssertEqual(
+            NotificationDelegateRouting.route(willPresent: foreignRemoteNotification(), hasForegroundHandler: false),
+            .forwardToExistingDelegate
+        )
+    }
+
+    func test_foreignRemoteNotification_isForwardedEvenWhenAForegroundHandlerIsRegistered() {
+        // The host app's foreground handler is for Optimove notifications. Registering one
+        // must not start swallowing other people's notifications.
+        XCTAssertEqual(
+            NotificationDelegateRouting.route(willPresent: foreignRemoteNotification(), hasForegroundHandler: true),
+            .forwardToExistingDelegate
+        )
+    }
+
+    func test_localNotification_isForwardedToTheDelegateWeReplaced() {
+        XCTAssertEqual(
+            NotificationDelegateRouting.route(willPresent: localNotification(), hasForegroundHandler: true),
+            .forwardToExistingDelegate
+        )
+    }
+
+    func test_optimoveNotification_withoutAForegroundHandler_isPresentedByUs() {
+        XCTAssertEqual(
+            NotificationDelegateRouting.route(willPresent: optimoveNotification(), hasForegroundHandler: false),
+            .presentWithDefaultOptions
+        )
+    }
+
+    func test_optimoveNotification_withAForegroundHandler_asksTheHandler() {
+        XCTAssertEqual(
+            NotificationDelegateRouting.route(willPresent: optimoveNotification(), hasForegroundHandler: true),
+            .invokeForegroundHandler
+        )
+    }
+
+    // MARK: - Responses
+
+    func test_foreignRemoteNotificationResponse_isForwardedToTheDelegateWeReplaced() {
+        XCTAssertEqual(
+            NotificationDelegateRouting.route(
+                didReceive: foreignRemoteNotification(),
+                actionIdentifier: UNNotificationDefaultActionIdentifier
+            ),
+            .forwardToExistingDelegate
+        )
+    }
+
+    func test_foreignRemoteNotificationDismissal_isForwardedToTheDelegateWeReplaced() {
+        XCTAssertEqual(
+            NotificationDelegateRouting.route(
+                didReceive: foreignRemoteNotification(),
+                actionIdentifier: UNNotificationDismissActionIdentifier
+            ),
+            .forwardToExistingDelegate
+        )
+    }
+
+    func test_localNotificationResponse_isForwardedToTheDelegateWeReplaced() {
+        XCTAssertEqual(
+            NotificationDelegateRouting.route(
+                didReceive: localNotification(),
+                actionIdentifier: UNNotificationDefaultActionIdentifier
+            ),
+            .forwardToExistingDelegate
+        )
+    }
+
+    func test_optimoveNotificationTap_isHandledAsAnOpen() {
+        XCTAssertEqual(
+            NotificationDelegateRouting.route(
+                didReceive: optimoveNotification(),
+                actionIdentifier: UNNotificationDefaultActionIdentifier
+            ),
+            .handleOpen
+        )
+    }
+
+    func test_optimoveNotificationCustomAction_isHandledAsAnOpen() {
+        XCTAssertEqual(
+            NotificationDelegateRouting.route(didReceive: optimoveNotification(), actionIdentifier: "reply"),
+            .handleOpen
+        )
+    }
+
+    func test_optimoveNotificationDismissal_isHandledAsADismissal() {
+        XCTAssertEqual(
+            NotificationDelegateRouting.route(
+                didReceive: optimoveNotification(),
+                actionIdentifier: UNNotificationDismissActionIdentifier
+            ),
+            .handleDismissal
+        )
+    }
+
+    // MARK: - Chaining
+
+    func test_delegate_chainsToTheDelegateItReplaced() {
+        let hostApp = HostAppDelegate()
+
+        let ours = OptimoveUserNotificationCenterDelegate(existingDelegate: hostApp)
+
+        XCTAssertTrue(ours.existingDelegate === hostApp)
+    }
+
+    func test_delegate_doesNotChainToAnotherDelegateOfOurs() {
+        let hostApp = HostAppDelegate()
+        let firstInstall = OptimoveUserNotificationCenterDelegate(existingDelegate: hostApp)
+
+        let secondInstall = OptimoveUserNotificationCenterDelegate(existingDelegate: firstInstall)
+
+        XCTAssertTrue(
+            secondInstall.existingDelegate === hostApp,
+            "Nesting our own delegates would handle each notification once per layer"
+        )
+    }
+
+    func test_delegate_toleratesTheHostAppHavingNoDelegate() {
+        let ours = OptimoveUserNotificationCenterDelegate(existingDelegate: nil)
+
+        XCTAssertNil(ours.existingDelegate)
+    }
+}


### PR DESCRIPTION
[AB#292768](https://mobius.visualstudio.com/7b12c5d6-c2cb-4957-9a09-46dfabf0bd18/_workitems/edit/292768)

### Description of Changes

**The premise of [AB#292768](https://mobius.visualstudio.com/7b12c5d6-c2cb-4957-9a09-46dfabf0bd18/_workitems/edit/292768) is partly wrong, and I want to state that before the fix.**
The bug says the SDK "silently drops" the host app's `UNUserNotificationCenter` delegate.
It does not. `OptimoveUserNotificationCenterDelegate` has captured the previous delegate and
forwarded to it since 2022, and every notification that is not ours reaches it:

| Notification | Today |
|---|---|
| Host app's own remote push | forwarded to their delegate |
| Another SDK's remote push | forwarded to their delegate |
| Host app's local notification | forwarded to their delegate |
| Optimove push | handled by us (by design — `setPushReceivedInForegroundHandler` / `setPushOpenedHandler` are the sanctioned hooks) |

So the headline defect from the handoff is not real. What *is* real, and what this PR fixes:

**1. The forwarding rule was untestable, and therefore unprotected.** It lived inline in two
protocol methods that a test cannot reach. `UNUserNotificationCenter.current()` raises in a
test bundle — measured, not assumed:

```
error: bundleProxyForCurrentProcess is nil: mainBundle.bundleURL
  file:///Applications/Xcode.app/.../Library/Xcode/Agents/ (NSInternalInconsistencyException)
```

and neither `UNNotification` nor `UNNotificationResponse` has an initializer. So the one rule
that keeps the host app working had zero coverage. `NotificationDelegateRouting` now holds it
as functions of the payload alone, and 11 tests pin it down — including that registering a
foreground handler must not start swallowing *other* people's notifications.

The extraction is behaviour-preserving. The old code decided by a mix of `push.id == 0`,
`userInfo["aps"] == nil`, and the `Bool` returned by `pushHandleOpen`/`pushHandleDismissed`.
All three reduce to the same predicate — an Optimove message id is present — because both
`pushHandle*` methods return `id != 0`, and a payload with no `aps` cannot parse an id. The
`if handled` fallback to chaining is kept as a safety net rather than replaced by the router's
decision.

**2. Re-installing over our own delegate nested the chain.** Each layer would handle the same
notification and forward it to the host app once per layer. Not reachable through
`Optimove.initialize` today, which is guarded by `instance == nil`, but the constructor now
refuses to wrap itself so it cannot become reachable.

**3. `UIApplication.shared.delegate!` crashed the app** when the SDK was initialized before
the application delegate was set. Now logged and skipped. Same for `object_getClass(delegate)!`
and the duplicate force-unwrap that shadowed the `klass` parameter inside
`swizzleDidFailRegister`.

**4. The install ran on whichever thread initialized the SDK.** `UIApplication.shared` is
main-thread only, and the swizzles write file-scope IMP globals. It is now confined to the
main thread, which also removes any race on those globals.

**5. Installing twice was unguarded.** `class_replaceMethod` would return our own IMP, and the
swizzled method would then call itself until the stack ran out. Unreachable today for the same
reason as (2) — I checked, rather than repeating the handoff's claim that it was live — but the
invariant is now explicit instead of accidental.

**6. The genuinely silent failure, now diagnosable.** Chaining only covers a delegate installed
*before* the SDK. One installed *after* replaces ours outright, and the SDK stops seeing
notifications entirely — no push opens, no in-app tickles, no log line. The install now checks
once the current run loop turn has drained and warns, which catches the common case of the
assignment happening later in `application(_:didFinishLaunchingWithOptions:)`. It does not
catch an assignment in a later turn (a `viewDidLoad`, say).

### Verification

Full suite: **89 tests, 0 failures** (75 before, plus the 14 added here).

Mutation-checked — the tests are not vacuous. Two mutations, `isOurs` forced to `true` and the
self-wrapping guard disabled, kill 7 of the 14:

```
test_foreignRemoteNotification_isForwardedToTheDelegateWeReplaced
  XCTAssertEqual failed: ("presentWithDefaultOptions") is not equal to ("forwardToExistingDelegate")
test_foreignRemoteNotification_isForwardedEvenWhenAForegroundHandlerIsRegistered
  XCTAssertEqual failed: ("invokeForegroundHandler") is not equal to ("forwardToExistingDelegate")
test_localNotificationResponse_isForwardedToTheDelegateWeReplaced
  XCTAssertEqual failed: ("handleOpen") is not equal to ("forwardToExistingDelegate")
test_delegate_doesNotChainToAnotherDelegateOfOurs
  XCTAssertTrue failed - Nesting our own delegates would handle each notification once per layer
  (+3 more)
Executed 14 tests, with 7 failures
```

### Deliberately not changed

**`existingDelegate` stays a strong reference,** although `UNUserNotificationCenter.delegate`
is weak and holding it strongly can keep a delegate alive that the host app has released.
Making it `weak` is the more correct ownership, but it can only *reduce* what the host app
receives, which is the opposite of this bug, and there is no way to test the lifetime change
here. Worth doing on its own.

**Optimove notifications still do not reach the host app's delegate.** Forwarding them too
would double-handle in every app that already uses `setPushOpenedHandler`, so it is a product
decision, not a bug fix.

**`PushNotification.init` keeps its force casts** (`msg["data"] as!`, `msgData["id"] as!`,
`Optimobile+Push.swift:47-49`). A payload carrying `custom.a.k.message` without a well-formed
`data.id` crashes, and this init now runs on every notification the app receives, ours or not.
Out of scope here, but it should be picked up.

### Breaking Changes

-   None

No public API changes. Behaviour changes are confined to cases that previously crashed or
silently did nothing.

### Release Checklist

### Prepare:

- [x] Detail any breaking changes. Breaking changes require a new major version number — none
- [ ] Check `pod lib lint` passes
- [ ] Update any relevant sections of the repository wiki pages on a branch — the push
      integration guide is worth a note that the notification-center delegate must be set
      before `Optimove.initialize`, which is what the new warning tells people at runtime

### Bump versions in:

Bumped to **6.8.3**. 6.8.1 and 6.8.2 are claimed by #144 and #147, both still open, so this
takes the next free patch number. Whichever of the three merges first should keep its number
and the others renumbered — none of them collide in `CHANGELOG.md` as they stand.

- [x] `OptimoveCore.podspec`
- [x] `OptimoveNotificationServiceExtension.podspec`
- [x] `OptimoveSDK.podspec`
- [x] `OptimoveCore/Sources/Classes/Constants/SDKVersion.swift`
- [ ] `README.md` — n/a, contains no version reference
- [x] `CHANGELOG.md`
- [ ] Update major version numbers in wiki (basic integration + push guides) — n/a, patch release

### Integration tests

Unit tests pass (89, 0 failures). The routing rules are covered, but the parts that only exist
at runtime need a device:

- Host app sets `UNUserNotificationCenter.current().delegate` **before** `Optimove.initialize`,
  then: an Optimove push opens and is tracked; the host app's own push still reaches their
  delegate; a local notification still reaches their delegate.
- Host app sets its delegate **after** `Optimove.initialize` — expect the new warning in the log.
- Initialize the SDK from a background thread and confirm push registration still works.

*T&T Only*

- [ ] Init SDK with only T&T credentials
- [ ] Track events

*Mobile Only*

- [ ] Init SDK with all credentials
- [ ] Track events
- [ ] Register for push
- [ ] Send test push
- [ ] Receive / trigger deep link handler (In-App/Push)
- [ ] Verify push opened handler

### Release:

- [ ] Squash and merge to master
- [ ] Delete branch once merged
