### PR TITLE
AB#292839 fix(push): stop force-casting the notification message payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.8.4
+
+- Fix a crash when parsing a notification payload that carries `k.message` without a well-formed `data.id`. The payload is now treated as not belonging to the SDK and forwarded to the host app's delegate, as any other unrecognised notification is.
+
 ## 6.8.0
 
 - Add `OptimoveOverlayMessaging.setActionHandler(_:)` — register a handler to intercept overlay CTA clicks and perform custom navigation instead of the SDK opening the URL.

--- a/OptimoveCore.podspec
+++ b/OptimoveCore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'OptimoveCore'
-  s.version          = '6.8.0'
+  s.version          = '6.8.4'
   s.summary          = 'Official Optimove SDK for iOS. Core framework.'
   s.description      = 'The core framework is used to share code-base between other Optimove frameworks.'
   s.homepage         = 'https://github.com/optimove-tech/Optimove-SDK-iOS'

--- a/OptimoveCore/Sources/Classes/Constants/SDKVersion.swift
+++ b/OptimoveCore/Sources/Classes/Constants/SDKVersion.swift
@@ -1,3 +1,3 @@
 //  Copyright © 2019 Optimove. All rights reserved.
 
-public let SDKVersion = "6.8.0"
+public let SDKVersion = "6.8.4"

--- a/OptimoveNotificationServiceExtension.podspec
+++ b/OptimoveNotificationServiceExtension.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'OptimoveNotificationServiceExtension'
-  s.version          = '6.8.0'
+  s.version          = '6.8.4'
   s.summary          = 'Official Optimove SDK for iOS. Notification service extension framework.'
   s.description      = 'The notification service extension is used for handling additional content in push notifications.'
   s.homepage         = 'https://github.com/optimove-tech/Optimove-SDK-iOS'

--- a/OptimoveSDK.podspec
+++ b/OptimoveSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'OptimoveSDK'
-  s.version          = '6.8.0'
+  s.version          = '6.8.4'
   s.summary          = 'Official Optimove SDK for iOS.'
   s.description      = 'The Optimove SDK framework is used for reporting events and receive push notifications.'
   s.homepage         = 'https://github.com/optimove-tech/Optimove-SDK-iOS'

--- a/OptimoveSDK/Sources/Classes/Optimobile/Optimobile+Push.swift
+++ b/OptimoveSDK/Sources/Classes/Optimobile/Optimobile+Push.swift
@@ -44,10 +44,21 @@ public class PushNotification: NSObject {
             return
         }
         
-        let msgData = msg["data"] as! [AnyHashable: Any]
-        
-        id = msgData["id"] as! Int
-        
+        // Anything below here is a payload that looks like ours but is not shaped like ours.
+        // Leaving `id` at 0 marks the notification as not ours, which is what the delegate
+        // needs in order to forward it to the host app instead of answering it.
+        guard let msgData = msg["data"] as? [AnyHashable: Any] else {
+            Logger.warn("Ignoring a notification whose k.message carries no data dictionary")
+            return
+        }
+
+        guard let messageId = msgData["id"] as? Int else {
+            Logger.warn("Ignoring a notification whose k.message data carries no numeric id")
+            return
+        }
+
+        id = messageId
+
         if let urlStr = custom["u"] as? String {
             url = URL(string: urlStr)
         } else {

--- a/OptimoveSDK/Tests/Sources/Optimobile/PushNotificationTests.swift
+++ b/OptimoveSDK/Tests/Sources/Optimobile/PushNotificationTests.swift
@@ -1,0 +1,83 @@
+//  Copyright © 2026 Optimove. All rights reserved.
+
+import XCTest
+@testable import OptimoveSDK
+
+/// `PushNotification.init(userInfo:)` runs on every notification the app receives, ours or
+/// not, so it has to survive a payload it does not recognise rather than take the host app
+/// down with it.
+final class PushNotificationTests: XCTestCase {
+    private func payload(message: Any?, url: String? = nil) -> [AnyHashable: Any] {
+        var custom: [AnyHashable: Any] = [:]
+        if let message = message {
+            custom["a"] = ["k.message": message]
+        }
+        if let url = url {
+            custom["u"] = url
+        }
+
+        return [
+            "aps": ["alert": ["title": "Title", "body": "Body"]],
+            "custom": custom,
+        ]
+    }
+
+    // MARK: - Well-formed payloads
+
+    func test_optimovePayload_parsesTheMessageId() {
+        let notification = PushNotification(userInfo: payload(message: ["data": ["id": 42]]))
+
+        XCTAssertEqual(notification.id, 42)
+    }
+
+    func test_optimovePayload_parsesTheDeepLinkUrl() {
+        let notification = PushNotification(
+            userInfo: payload(message: ["data": ["id": 42]], url: "https://example.com/offer")
+        )
+
+        XCTAssertEqual(notification.url, URL(string: "https://example.com/offer"))
+    }
+
+    func test_optimovePayload_exposesApsAndData() {
+        let notification = PushNotification(userInfo: payload(message: ["data": ["id": 42]]))
+
+        XCTAssertNotNil(notification.aps["alert"])
+        XCTAssertNotNil(notification.data["k.message"])
+    }
+
+    // MARK: - Payloads that are not ours
+
+    func test_noPayload_hasNoMessageId() {
+        XCTAssertEqual(PushNotification(userInfo: nil).id, 0)
+    }
+
+    func test_payloadWithoutAps_hasNoMessageId() {
+        XCTAssertEqual(PushNotification(userInfo: ["myAppsOwnKey": "value"]).id, 0)
+    }
+
+    func test_payloadWithoutCustom_hasNoMessageId() {
+        XCTAssertEqual(PushNotification(userInfo: ["aps": ["alert": "Sent by someone else"]]).id, 0)
+    }
+
+    func test_payloadWithoutAMessage_hasNoMessageId() {
+        XCTAssertEqual(PushNotification(userInfo: payload(message: nil)).id, 0)
+    }
+
+    // MARK: - Malformed payloads that used to crash
+
+    func test_messageWithoutADataDictionary_hasNoMessageId() {
+        XCTAssertEqual(PushNotification(userInfo: payload(message: ["unexpected": "shape"])).id, 0)
+    }
+
+    func test_messageWithANonDictionaryData_hasNoMessageId() {
+        XCTAssertEqual(PushNotification(userInfo: payload(message: ["data": "not a dictionary"])).id, 0)
+    }
+
+    func test_messageWithoutAnId_hasNoMessageId() {
+        XCTAssertEqual(PushNotification(userInfo: payload(message: ["data": ["noId": true]])).id, 0)
+    }
+
+    func test_messageWithANonNumericId_hasNoMessageId() {
+        XCTAssertEqual(PushNotification(userInfo: payload(message: ["data": ["id": "42"]])).id, 0)
+    }
+}


### PR DESCRIPTION
[AB#292839](https://mobius.visualstudio.com/7b12c5d6-c2cb-4957-9a09-46dfabf0bd18/_workitems/edit/292839)

### Description of Changes

`PushNotification.init(userInfo:)` force-cast two values it had not checked:

```swift
let msgData = msg["data"] as! [AnyHashable: Any]
id = msgData["id"] as! Int
```

A payload carrying `custom.a.k.message` without a well-formed `data.id` took the host app down.
This initialiser runs on **every** notification the app receives, ours or not — both
`UNUserNotificationCenter` delegate methods build a `PushNotification` before deciding whose
notification it is — so a malformed payload from any sender was enough.

Both casts are now checked. Leaving `id` at 0 marks the notification as not ours, which is
already how the delegate decides to forward it to the host app's delegate, so a payload we
cannot read is treated the same as any other notification that is not ours.

### Verification

**The crash reproduces.** Running the new tests against `master` gives four distinct crashes,
one per malformed shape, at exactly the two lines above:

```
Could not cast value of type 'Swift.String' to 'Swift.Dictionary<Swift.AnyHashable, Any>'
Could not cast value of type 'Swift.String' to 'Swift.Int'
OptimoveSDK/Optimobile+Push.swift:47: Fatal error: Unexpectedly found nil while unwrapping an Optional value
OptimoveSDK/Optimobile+Push.swift:49: Fatal error: Unexpectedly found nil while unwrapping an Optional value
```

Each one kills the test process, which is what the crash does to a host app. With the fix, the
same 11 tests pass and nothing crashes.

Full suite: **86 tests, 0 failures** (75 before, plus the 11 added here).

The 11 tests cover the well-formed payload (message id, deep link URL, `aps`/`data` passthrough),
the payloads that were already handled (no payload, no `aps`, no `custom`, no `k.message`), and
the four that crashed (no `data`, `data` not a dictionary, no `id`, `id` not a number).

### One consequence worth naming

A malformed id used to crash loudly. It now logs a warning and the notification is treated as
not ours. If the push service ever changed the id's type, the old behaviour would have produced
a crash report, whereas this will silently stop attributing opens. That is why both branches log
rather than return quietly — the log line is what makes it diagnosable:

```
Ignoring a notification whose k.message carries no data dictionary
Ignoring a notification whose k.message data carries no numeric id
```

Accepting a string id as well would paper over exactly that kind of change, so the check stays
strict.

### Breaking Changes

-   None

No public API change. The only behaviour change is in cases that previously crashed.

### Release Checklist

### Prepare:

- [x] Detail any breaking changes. Breaking changes require a new major version number — none
- [ ] Check `pod lib lint` passes
- [ ] Update any relevant sections of the repository wiki pages on a branch — n/a, no public API change

### Bump versions in:

Bumped to **6.8.4**, the next number not already claimed by an open PR (6.8.1 → #144,
6.8.2 → #147, 6.8.3 → #148). **This is not sustainable:** with several PRs open at once, a
per-PR bump means whichever merges first is right and the rest have to be renumbered. Worth
deciding to bump once at release time instead, and dropping the version rows from the per-PR
checklist.

- [x] `OptimoveCore.podspec`
- [x] `OptimoveNotificationServiceExtension.podspec`
- [x] `OptimoveSDK.podspec`
- [x] `OptimoveCore/Sources/Classes/Constants/SDKVersion.swift`
- [ ] `README.md` — n/a, contains no version reference
- [x] `CHANGELOG.md`
- [ ] Update major version numbers in wiki (basic integration + push guides) — n/a, patch release

### Integration tests

Unit tests pass (86, 0 failures). Parsing is fully covered by them; what needs a device is only
that a normal Optimove push is unaffected:

- [ ] Init SDK with all credentials
- [ ] Register for push
- [ ] Send test push, verify it opens and the open is attributed
- [ ] Receive / trigger deep link handler (In-App/Push)

### Release:

- [ ] Squash and merge to master
- [ ] Delete branch once merged
