### PR TITLE
AB#268289 test: make the auth and analytics timing tests deterministic

### DIFF
--- a/OptimoveCore/Tests/Sources/Auth/AuthManagerTests.swift
+++ b/OptimoveCore/Tests/Sources/Auth/AuthManagerTests.swift
@@ -3,6 +3,12 @@
 import XCTest
 @testable import OptimoveCore
 
+/// Deliberately generous: the waits in these tests bound work that has already been forced to
+/// happen, so a slow machine can only make them take longer, never change the outcome. A tight
+/// bound is what turns a deterministic test back into a flaky one — the suite has been measured
+/// taking 11x longer under full CPU load.
+private let generousTimeout: TimeInterval = 10
+
 final class AuthManagerTests: XCTestCase {
 
     // MARK: - 1.1 getToken calls provider with correct userId
@@ -107,37 +113,66 @@ final class AuthManagerTests: XCTestCase {
             }
             completionExpectation.fulfill()
         }
-        waitForExpectations(timeout: 1)
+        // Unlike the tests above, this one waits on a real timer rather than a synchronous
+        // callback, so it gets the generous bound.
+        waitForExpectations(timeout: generousTimeout)
     }
 
     // MARK: - 1.6 getToken ignores provider completion after timeout
 
+    /// The ordering under test — provider answers *after* the timeout — is enforced rather than
+    /// raced. The provider holds its token until the test has seen the timeout, so no arrangement
+    /// of wall-clock delays can invert the two, however loaded the machine is. Every wait is then
+    /// a generous upper bound on something that has already been made to happen, which is what
+    /// makes the test deterministic: load can only make it slower, never wrong.
     func test_getToken_ignoresProviderCompletionAfterTimeout() {
-        let timeoutExpectation = expectation(description: "Completion should receive timeout once")
-        let lateCompletionExpectation = expectation(description: "Late provider completion should be ignored")
-        lateCompletionExpectation.isInverted = true
+        let releaseLateToken = DispatchSemaphore(value: 0)
+        let providerAsked = expectation(description: "The provider was asked for a token")
+        let firstCompletion = expectation(description: "getToken called its completion")
+        let lateTokenDelivered = expectation(description: "The provider delivered its token after the timeout")
 
-        let authManager = AuthManager(tokenFetchTimeout: 0.1) { _, completion in
-            // Match the .utility QoS that AuthManager's own timeout timer runs on, so this
-            // isn't racing a lower-priority timer under system load (which caused flakiness).
-            DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 0.3) {
+        let authManager = AuthManager(tokenFetchTimeout: 0.05) { _, completion in
+            providerAsked.fulfill()
+            DispatchQueue.global(qos: .utility).async {
+                releaseLateToken.wait()
                 completion("late-token", nil)
+                lateTokenDelivered.fulfill()
             }
         }
+
+        // Record rather than assert inside the callback: a callback that never runs cannot fail a
+        // test from the inside, and a second, wrongly delivered call has to be counted to be seen.
+        let resultsLock = NSLock()
+        var results: [Result<String, Error>] = []
 
         authManager.getToken(userId: "user-123") { result in
-            switch result {
-            case .success:
-                lateCompletionExpectation.fulfill()
-            case .failure(let error):
-                guard let authError = error as? AuthError else {
-                    XCTFail("Expected AuthError but got \(type(of: error))")
-                    return
-                }
-                XCTAssertEqual(authError, AuthError.tokenFetchTimedOut)
-                timeoutExpectation.fulfill()
+            resultsLock.lock()
+            results.append(result)
+            let isFirst = results.count == 1
+            resultsLock.unlock()
+
+            if isFirst {
+                firstCompletion.fulfill()
             }
         }
-        wait(for: [timeoutExpectation, lateCompletionExpectation], timeout: 0.6)
+
+        wait(for: [providerAsked, firstCompletion], timeout: generousTimeout)
+
+        // The timeout has now been observed, so anything the provider delivers from here is late
+        // by construction.
+        releaseLateToken.signal()
+        wait(for: [lateTokenDelivered], timeout: generousTimeout)
+
+        resultsLock.lock()
+        let observed = results
+        resultsLock.unlock()
+
+        XCTAssertEqual(observed.count, 1, "The token that arrived after the timeout should have been dropped")
+
+        guard case let .failure(error)? = observed.first else {
+            XCTFail("Expected a single timeout failure, got \(observed)")
+            return
+        }
+        XCTAssertEqual(error as? AuthError, AuthError.tokenFetchTimedOut)
     }
 }

--- a/OptimoveSDK/Tests/Sources/Optimobile/AnalyticsHelperTests.swift
+++ b/OptimoveSDK/Tests/Sources/Optimobile/AnalyticsHelperTests.swift
@@ -78,53 +78,63 @@ class AnalyticsHelperTests: XCTestCase {
 
     func test_number_of_sent_events_with_delays_same_as_tracked() {
         let numberOfEvents = 4
-        let numberOfEventsExpectation = expectation(description: "Completion for delayed burst fired")
+        let firstBurstDelivered = expectation(description: "The first event was delivered")
+        let secondBurstDelivered = expectation(description: "The second burst was delivered")
         let mock = mockHttpClient!
         let helper = analyticsHelper!
 
-        helper.trackEvent(eventType: "immediate_event_first", properties: nil, immediateFlush: true)
+        // What this test is about is the second burst starting *after* the first drain finished.
+        // Waiting for the first delivery says so directly; sleeping and hoping the drain fit in
+        // the nap makes it a race, and a loaded machine is exactly where the nap is too short.
+        helper.trackEvent(eventType: "immediate_event_first", atTime: Date(), properties: nil, immediateFlush: true) { _ in
+            firstBurstDelivered.fulfill()
+        }
+        wait(for: [firstBurstDelivered], timeout: longTimeoutInSeconds)
 
-        // A short real sleep is enough to exercise the "second burst after the first drain
-        // completed" path; it doesn't need to be long, and a smaller value leaves more of the
-        // longTimeoutInSeconds budget as margin against CI slowness.
-        DispatchQueue.global().asyncAfter(deadline: .now() + 0.5) {
-            for i in 1...numberOfEvents - 1 {
-                helper.trackEvent(eventType: "immediate_event\(i)", properties: nil, immediateFlush: true)
-            }
-
-            helper.trackEvent(eventType: "immediate_event_last", atTime: Date(), properties: nil, immediateFlush: true) { _ in
-                // Fulfill unconditionally so a count mismatch fails fast with the actual number
-                // below, instead of silently burning the full timeout with an opaque
-                // "Asynchronous wait failed" error.
-                numberOfEventsExpectation.fulfill()
-            }
+        for i in 1...numberOfEvents - 1 {
+            helper.trackEvent(eventType: "immediate_event\(i)", properties: nil, immediateFlush: true)
         }
 
-        waitForExpectations(timeout: longTimeoutInSeconds, handler: nil)
-        // +1 for immediate_event_first tracked before the delay
+        helper.trackEvent(eventType: "immediate_event_last", atTime: Date(), properties: nil, immediateFlush: true) { _ in
+            secondBurstDelivered.fulfill()
+        }
+        // The helper drains on one serial queue, so by the time the last event's send has completed
+        // the earlier ones in the burst have too.
+        wait(for: [secondBurstDelivered], timeout: longTimeoutInSeconds)
+
+        // +1 for immediate_event_first, delivered before the burst
         XCTAssertEqual(mock.totalEventCount, numberOfEvents + 1)
     }
 
     func test_number_of_sent_events_from_background_threads_same_as_tracked() {
         let numberOfEvents = 4
-        let numberOfEventsExpectation = expectation(description: "Number of events wasnt \(numberOfEvents)")
+        let backgroundEventsDelivered = expectation(description: "The events tracked from background queues were delivered")
+        backgroundEventsDelivered.expectedFulfillmentCount = numberOfEvents - 1
+        let lastEventDelivered = expectation(description: "The last event was delivered")
 
         let mock = mockHttpClient!
         let helper = analyticsHelper!
 
         for i in 1...numberOfEvents - 1 {
             DispatchQueue.global().async {
-                helper.trackEvent(eventType: "immediate_event\(i)", properties: nil, immediateFlush: true)
+                helper.trackEvent(eventType: "immediate_event\(i)", atTime: Date(), properties: nil, immediateFlush: true) { _ in
+                    backgroundEventsDelivered.fulfill()
+                }
             }
         }
 
-        helper.trackEvent(eventType: "immediate_event_last", atTime: Date(), properties: nil, immediateFlush: true) {_ in
-            if let data = mock.capturedData as? [[String: Any?]], data.count == numberOfEvents {
-                numberOfEventsExpectation.fulfill()
-            }
-        }
+        // Still tracked concurrently from several queues, which is the point — but the count is
+        // only checked once those deliveries are known to have happened. Tracking the last event
+        // straight away instead left the assertion racing the background queues, and the loser
+        // was whichever the scheduler felt like.
+        wait(for: [backgroundEventsDelivered], timeout: longTimeoutInSeconds)
 
-        waitForExpectations(timeout: longTimeoutInSeconds, handler: nil)
+        helper.trackEvent(eventType: "immediate_event_last", atTime: Date(), properties: nil, immediateFlush: true) { _ in
+            lastEventDelivered.fulfill()
+        }
+        wait(for: [lastEventDelivered], timeout: longTimeoutInSeconds)
+
+        XCTAssertEqual(mock.totalEventCount, numberOfEvents)
     }
 
     func test_immediate_event_should_grab_nonimmediate() {
@@ -144,45 +154,63 @@ class AnalyticsHelperTests: XCTestCase {
     
     func test_failed_network_event_should_be_picked_up_by_subsequent() {
         let mockKSHttpClientSingleFailure = MockKSHttpClientSingleFailure()
-        let analyticsHelper = AnalyticsHelper(httpClient: mockKSHttpClientSingleFailure, storeUrlOverride: Self.makeTemporaryStoreUrl())
-        
-        let failedEventExpectation = expectation(description: "Failed event wasn't sent on next dispatch")
+        let storeUrl = Self.makeTemporaryStoreUrl()
+        let analyticsHelper = AnalyticsHelper(httpClient: mockKSHttpClientSingleFailure, storeUrlOverride: storeUrl)
+        defer { Self.removeStore(at: storeUrl) }
+
+        // The second event has to be tracked after the first send has actually failed, otherwise
+        // there is nothing for it to pick up. The mock says when that happened instead of the test
+        // sleeping for two seconds and assuming it did.
+        let firstSendFailed = expectation(description: "The first send was answered with a failure")
+        mockKSHttpClientSingleFailure.onFailureDelivered = { firstSendFailed.fulfill() }
 
         analyticsHelper.trackEvent(eventType: "immeditate_event", properties: nil, immediateFlush: true)
-        
-        DispatchQueue.global().asyncAfter(deadline: .now() + 2) {
-            analyticsHelper.trackEvent(eventType: "immediate_event_second", atTime: Date(), properties: nil, immediateFlush: true) {_ in
-                if let data = mockKSHttpClientSingleFailure.capturedData as? [[String: Any?]], data.count == 2 {
-                    failedEventExpectation.fulfill()
-                }
-            }
+        wait(for: [firstSendFailed], timeout: longTimeoutInSeconds)
+
+        let secondSendDelivered = expectation(description: "The second send completed")
+        analyticsHelper.trackEvent(eventType: "immediate_event_second", atTime: Date(), properties: nil, immediateFlush: true) { _ in
+            secondSendDelivered.fulfill()
         }
-        
-        waitForExpectations(timeout: longTimeoutInSeconds, handler: nil)
+        wait(for: [secondSendDelivered], timeout: longTimeoutInSeconds)
+
+        let batch = mockKSHttpClientSingleFailure.capturedData as? [[String: Any?]]
+        XCTAssertEqual(batch?.count, 2, "The event whose send failed should be retried alongside the next one")
     }
     
 }
 
+/// `sendRequest` is called from the helper's serial queue while the tests read these properties
+/// from the test thread, so the state is behind a lock. Without it the tests race the mock itself,
+/// and a torn read of an array is a corrupt count, not a caught bug.
 class MockKSHttpClient: KSHttpClient {
+    private let lock = NSLock()
     private var allBatches: [[String: Any?]] = []
+    private var authUserIds: [String?] = []
 
     // Events accumulated across all sendRequest calls.
-    var capturedData: Any? { allBatches.isEmpty ? nil : allBatches }
-    var totalEventCount: Int { allBatches.count }
+    var capturedData: Any? { withLock { allBatches.isEmpty ? nil : allBatches } }
+    var totalEventCount: Int { withLock { allBatches.count } }
 
     // Last authUserId seen, and the full history.
-    var capturedAuthUserId: String?
-    var capturedAuthUserIds: [String?] = []
+    var capturedAuthUserId: String? { withLock { authUserIds.last ?? nil } }
+    var capturedAuthUserIds: [String?] { withLock { authUserIds } }
+
+    private func withLock<T>(_ body: () -> T) -> T {
+        lock.lock()
+        defer { lock.unlock() }
+        return body()
+    }
 
     func sendRequest(_ method: OptimoveSDK.KSHttpMethod, toPath path: String, data: Any?, authUserId: String?, onSuccess: @escaping OptimoveSDK.KSHttpSuccessBlock, onFailure: @escaping OptimoveSDK.KSHttpFailureBlock) {
-        if let batch = data as? [[String: Any?]] {
-            allBatches.append(contentsOf: batch)
+        withLock {
+            if let batch = data as? [[String: Any?]] {
+                allBatches.append(contentsOf: batch)
+            }
+            authUserIds.append(authUserId)
         }
-        capturedAuthUserId = authUserId
-        capturedAuthUserIds.append(authUserId)
         onSuccess(nil, nil)
     }
-    
+
     func invalidateSessionCancellingTasks(_ cancel: Bool) {
         return
     }
@@ -249,19 +277,41 @@ class AnalyticsHelperAuthTests: XCTestCase {
 }
 
 class MockKSHttpClientSingleFailure: KSHttpClient {
-    var capturedData: Any?
-    var failed = false
-    
-    func sendRequest(_ method: OptimoveSDK.KSHttpMethod, toPath path: String, data: Any?, authUserId: String?, onSuccess: @escaping OptimoveSDK.KSHttpSuccessBlock, onFailure: @escaping OptimoveSDK.KSHttpFailureBlock) {
-        if !failed {
-            onFailure(nil, NSError(domain: "domain", code: 404), nil)
-            failed = true
-        } else {
-            capturedData = data
-            onSuccess(nil, nil)
-        }
+    private let lock = NSLock()
+    private var lastSuccessfulBatch: Any?
+    private var failed = false
+
+    var capturedData: Any? { withLock { lastSuccessfulBatch } }
+
+    /// Fires once the first request has been answered with a failure, so a test can sequence the
+    /// next request after it rather than sleeping for long enough and hoping.
+    var onFailureDelivered: (() -> Void)?
+
+    private func withLock<T>(_ body: () -> T) -> T {
+        lock.lock()
+        defer { lock.unlock() }
+        return body()
     }
-    
+
+    func sendRequest(_ method: OptimoveSDK.KSHttpMethod, toPath path: String, data: Any?, authUserId: String?, onSuccess: @escaping OptimoveSDK.KSHttpSuccessBlock, onFailure: @escaping OptimoveSDK.KSHttpFailureBlock) {
+        let isFirstRequest = withLock { () -> Bool in
+            guard !failed else { return false }
+            failed = true
+            return true
+        }
+
+        if isFirstRequest {
+            onFailure(nil, NSError(domain: "domain", code: 404), nil)
+            // After the helper has handled the failure, so a test resuming here sees the event
+            // already back in the store.
+            onFailureDelivered?()
+            return
+        }
+
+        withLock { lastSuccessfulBatch = data }
+        onSuccess(nil, nil)
+    }
+
     func invalidateSessionCancellingTasks(_ cancel: Bool) {
         return
     }


### PR DESCRIPTION
[AB#268289](https://mobius.visualstudio.com/7b12c5d6-c2cb-4957-9a09-46dfabf0bd18/_workitems/edit/268289)

Targets `feature/268289-auth`, not `master` — this is a follow-up to #134, not a separate change.

### Description of Changes

#134 already found the real cause of the `AnalyticsHelperTests` flake, and the `storeUrlOverride`
per-test store is the right fix — better than deleting a shared database file, which is what I had
done independently in #146. This PR does not touch that.

What it changes is the tests that still decide their outcome by racing wall-clock delays. Those
flake when the machine is slow, not when the code is wrong, which is the worst property a test can
have: it fails for a reason unrelated to the change under review, and it passes a regression when
the machine happens to be fast.

**`test_getToken_ignoresProviderCompletionAfterTimeout`** raced a 0.1s timeout against a 0.3s
provider inside a 0.6s wait. Two ways to fail without any bug: the timer slips past 0.3s and the
provider wins, or the whole thing exceeds 0.6s. Widening the margins to 3x makes both less likely
but neither impossible.

The ordering under test — *provider answers after the timeout* — is now enforced instead of raced.
The provider blocks on a semaphore the test only signals once it has seen the timeout, so no
scheduling can invert the two:

```swift
let authManager = AuthManager(tokenFetchTimeout: 0.05) { _, completion in
    providerAsked.fulfill()
    DispatchQueue.global(qos: .utility).async {
        releaseLateToken.wait()
        completion("late-token", nil)
        lateTokenDelivered.fulfill()
    }
}
...
wait(for: [providerAsked, firstCompletion], timeout: generousTimeout)
releaseLateToken.signal()               // anything from here is late by construction
wait(for: [lateTokenDelivered], timeout: generousTimeout)

XCTAssertEqual(observed.count, 1, "The token that arrived after the timeout should have been dropped")
```

The inverted expectation is gone too. Counting the completions says the same thing and says it
better: an inverted expectation reports "something happened that shouldn't have", a count reports
`(2) is not equal to (1)`.

**Three more, same class:**

| Test | Was | Now |
|---|---|---|
| `..._with_delays_same_as_tracked` | slept 0.5s, assumed the first drain finished | waits for the first delivery |
| `..._failed_network_event_should_be_picked_up_by_subsequent` | slept 2s, assumed the first send failed | the mock reports when it did (`onFailureDelivered`) |
| `..._from_background_threads_same_as_tracked` | counted while background queues were still delivering | still tracks concurrently, counts once those deliveries are known |

**Both mocks were unsynchronised.** `MockKSHttpClient.allBatches` and
`MockKSHttpClientSingleFailure`'s state are written from the helper's serial queue and read from
the test thread. A torn read of an array is a corrupt count, not a caught bug, so the tests could
race the mock itself regardless of anything the code under test did. Both are now behind a lock.

### Verification

Full suite: **85 tests, 0 failures.** No production code changed.

**Mutation-checked.** Removing `AuthManager.completeOnce`'s `didComplete` guard — the exact
behaviour the test exists to protect — fails it, and with a message that names the problem:

```
AuthManagerTests.swift:170: error: test_getToken_ignoresProviderCompletionAfterTimeout :
XCTAssertEqual failed: ("2") is not equal to ("1")
  - The token that arrived after the timeout should have been dropped
```

**The suite got faster:** ~9s → ~5.3s, because two real sleeps totalling 2.5s are gone.

### What I could not verify, and why the change still stands

I tried to measure whether the flake is gone, and the measurement has no power, so I am not
claiming it. Running `AnalyticsHelperTests` 8 times under full 11-core CPU load **on unfixed
`master`** passed 8/8 — the suite slowed from 2.8s to 31s, so the load was biting, but the flake
did not reproduce. It needs something about the GitHub-hosted runner that I cannot reproduce
locally. So my 10/10 on `feature/268289-auth` says nothing either, and neither run is evidence
about #134's fix.

The argument for this PR is structural rather than statistical: a test with no wall-clock margin
in it has no margin to lose. Every wait that remains bounds something already forced to happen, so
load can make these tests slower and nothing else.

The one wait I did **not** make deterministic is
`test_getToken_returnsTimeoutWhenProviderDoesNotComplete` — it waits on a real 0.05s timer,
because that is the thing under test. Its bound went from 1s to the generous constant.

### Breaking Changes

-   None

Test-only. No version bump — this rides on #134's 6.9.0.

### Release Checklist

Covered by #134; nothing separate to release.

- [x] Detail any breaking changes — none, tests only
- [ ] `pod lib lint` — n/a, no shipped code changed
- [ ] Wiki — n/a

### Integration tests

n/a — no shipped code changed.
