### PR TITLE
AB#293018 - Safe in-app message casting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.8.1
+
+- Fix crash during in-app message sync when remote message `content` is missing or not a dictionary. Invalid payloads are now skipped using Overlay-style safe parsing instead of force-casting during Core Data persistence.
+
 ## 6.8.0
 
 - Add `OptimoveOverlayMessaging.setActionHandler(_:)` — register a handler to intercept overlay CTA clicks and perform custom navigation instead of the SDK opening the URL.

--- a/OptimoveCore.podspec
+++ b/OptimoveCore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'OptimoveCore'
-  s.version          = '6.8.0'
+  s.version          = '6.8.1'
   s.summary          = 'Official Optimove SDK for iOS. Core framework.'
   s.description      = 'The core framework is used to share code-base between other Optimove frameworks.'
   s.homepage         = 'https://github.com/optimove-tech/Optimove-SDK-iOS'

--- a/OptimoveCore/Sources/Classes/Constants/SDKVersion.swift
+++ b/OptimoveCore/Sources/Classes/Constants/SDKVersion.swift
@@ -1,3 +1,3 @@
 //  Copyright © 2019 Optimove. All rights reserved.
 
-public let SDKVersion = "6.8.0"
+public let SDKVersion = "6.8.1"

--- a/OptimoveNotificationServiceExtension.podspec
+++ b/OptimoveNotificationServiceExtension.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'OptimoveNotificationServiceExtension'
-  s.version          = '6.8.0'
+  s.version          = '6.8.1'
   s.summary          = 'Official Optimove SDK for iOS. Notification service extension framework.'
   s.description      = 'The notification service extension is used for handling additional content in push notifications.'
   s.homepage         = 'https://github.com/optimove-tech/Optimove-SDK-iOS'

--- a/OptimoveSDK.podspec
+++ b/OptimoveSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'OptimoveSDK'
-  s.version          = '6.8.0'
+  s.version          = '6.8.1'
   s.summary          = 'Official Optimove SDK for iOS.'
   s.description      = 'The Optimove SDK framework is used for reporting events and receive push notifications.'
   s.homepage         = 'https://github.com/optimove-tech/Optimove-SDK-iOS'

--- a/OptimoveSDK/Sources/Classes/Optimobile/InApp/InAppManager.swift
+++ b/OptimoveSDK/Sources/Classes/Optimobile/InApp/InAppManager.swift
@@ -330,18 +330,19 @@ class InAppManager {
             }
 
             var mostRecentUpdate = NSDate(timeIntervalSince1970: 0)
-            let dateParser = DateFormatter()
-            dateParser.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
-            dateParser.locale = Locale(identifier: "en_US_POSIX")
-            dateParser.timeZone = TimeZone(secondsFromGMT: 0)
+            let dateParser = InAppMessageParser.makeDateParser()
 
             var fetchedWithInbox = false
+            var persistedMessages: [[AnyHashable: Any]] = []
             for message in messages {
-                let partId = message["id"] as! Int64
+                guard let parsed = InAppMessageParser.parseRequiredFields(from: message, dateParser: dateParser) else {
+                    print("InAppManager: Skipping message with invalid required fields")
+                    continue
+                }
 
                 let fetchRequest: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest(entityName: "Message")
                 fetchRequest.entity = entity
-                let predicate = NSPredicate(format: "id = %i", partId)
+                let predicate = NSPredicate(format: "id = %i", parsed.id)
                 fetchRequest.predicate = predicate
 
                 var fetchedObjects: [InAppMessageEntity]
@@ -354,12 +355,12 @@ class InAppManager {
                 // Upsert
                 let model: InAppMessageEntity = fetchedObjects.count == 1 ? fetchedObjects[0] : InAppMessageEntity(entity: entity!, insertInto: context)
 
-                model.id = partId
-                model.updatedAt = dateParser.date(from: message["updatedAt"] as! String)! as NSDate
+                model.id = parsed.id
+                model.updatedAt = parsed.updatedAt as NSDate
                 if model.dismissedAt == nil {
                     model.dismissedAt = dateParser.date(from: message["openedAt"] as? String ?? "") as NSDate?
                 }
-                model.presentedWhen = message["presentedWhen"] as! String
+                model.presentedWhen = parsed.presentedWhen
 
                 if model.readAt == nil {
                     model.readAt = dateParser.date(from: message["readAt"] as? String ?? "") as NSDate?
@@ -369,7 +370,7 @@ class InAppManager {
                     model.sentAt = dateParser.date(from: message["sentAt"] as? String ?? "") as NSDate?
                 }
 
-                model.content = message["content"] as! NSDictionary
+                model.content = parsed.content
                 model.data = message["data"] as? NSDictionary
                 model.badgeConfig = message["badge"] as? NSDictionary
                 model.inboxConfig = message["inbox"] as? NSDictionary
@@ -400,6 +401,8 @@ class InAppManager {
                 if model.updatedAt.timeIntervalSince1970 > mostRecentUpdate.timeIntervalSince1970 {
                     mostRecentUpdate = model.updatedAt
                 }
+
+                persistedMessages.append(message)
             }
 
             // Evict
@@ -432,7 +435,7 @@ class InAppManager {
 
             UserDefaults.standard.set(mostRecentUpdate, forKey: OptimobileUserDefaultsKey.IN_APP_MOST_RECENT_UPDATED_AT.rawValue)
 
-            trackMessageDelivery(messages: messages)
+            trackMessageDelivery(messages: persistedMessages)
 
             let inboxUpdated = fetchedWithInbox || evictedWithInbox || evictedExceedersWithInbox
             OptimoveInApp.maybeRunInboxUpdatedHandler(inboxNeedsUpdate: inboxUpdated)
@@ -620,7 +623,10 @@ class InAppManager {
 
     private func trackMessageDelivery(messages: [[AnyHashable: Any]]) {
         for message in messages {
-            let props: [String: Any] = ["type": MESSAGE_TYPE_IN_APP, "id": message["id"] as! Int]
+            guard let id = (message["id"] as? NSNumber)?.intValue else {
+                continue
+            }
+            let props: [String: Any] = ["type": MESSAGE_TYPE_IN_APP, "id": id]
             Optimobile.trackEvent(eventType: OptimobileEvent.MESSAGE_DELIVERED, properties: props)
         }
     }

--- a/OptimoveSDK/Sources/Classes/Optimobile/InApp/InAppMessageParser.swift
+++ b/OptimoveSDK/Sources/Classes/Optimobile/InApp/InAppMessageParser.swift
@@ -1,0 +1,44 @@
+//  Copyright © 2026 Optimove. All rights reserved.
+
+import Foundation
+
+/// Required fields for persisting an in-app message from the sync API payload.
+struct InAppMessageRequiredFields {
+    let id: Int64
+    let content: NSDictionary
+    let updatedAt: Date
+    let presentedWhen: String
+}
+
+/// Parses untyped JSON dictionaries from `/v1/users/{id}/messages`.
+/// Mirrors the defensive approach used by `OverlayMessagingRequestService.buildMessage`.
+enum InAppMessageParser {
+    static func makeDateParser() -> DateFormatter {
+        let dateParser = DateFormatter()
+        dateParser.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
+        dateParser.locale = Locale(identifier: "en_US_POSIX")
+        dateParser.timeZone = TimeZone(secondsFromGMT: 0)
+        return dateParser
+    }
+
+    static func parseRequiredFields(
+        from message: [AnyHashable: Any],
+        dateParser: DateFormatter = makeDateParser()
+    ) -> InAppMessageRequiredFields? {
+        guard let id = (message["id"] as? NSNumber)?.int64Value,
+              let content = message["content"] as? NSDictionary,
+              let updatedAtString = message["updatedAt"] as? String,
+              let updatedAt = dateParser.date(from: updatedAtString),
+              let presentedWhen = message["presentedWhen"] as? String
+        else {
+            return nil
+        }
+
+        return InAppMessageRequiredFields(
+            id: id,
+            content: content,
+            updatedAt: updatedAt,
+            presentedWhen: presentedWhen
+        )
+    }
+}

--- a/OptimoveSDK/Tests/Sources/Optimobile/InAppMessageParserTests.swift
+++ b/OptimoveSDK/Tests/Sources/Optimobile/InAppMessageParserTests.swift
@@ -1,0 +1,102 @@
+import XCTest
+@testable import OptimoveSDK
+
+final class InAppMessageParserTests: XCTestCase {
+
+    private let dateParser = InAppMessageParser.makeDateParser()
+
+    private func validMessage(overrides: [AnyHashable: Any] = [:]) -> [AnyHashable: Any] {
+        var message: [AnyHashable: Any] = [
+            "id": NSNumber(value: 42),
+            "content": ["html": "<p>Hello</p>"] as NSDictionary,
+            "updatedAt": "2026-08-06T12:00:00Z",
+            "presentedWhen": "immediately",
+        ]
+        for (key, value) in overrides {
+            message[key] = value
+        }
+        return message
+    }
+
+    // MARK: - Valid payload
+
+    func testParsesValidMessage() {
+        let parsed = InAppMessageParser.parseRequiredFields(from: validMessage(), dateParser: dateParser)
+
+        XCTAssertEqual(parsed?.id, 42)
+        XCTAssertEqual(parsed?.presentedWhen, "immediately")
+        XCTAssertEqual(parsed?.content["html"] as? String, "<p>Hello</p>")
+        XCTAssertNotNil(parsed?.updatedAt)
+    }
+
+    func testParsesLargeNumericId() {
+        let message = validMessage(overrides: ["id": NSNumber(value: Int64.max)])
+        let parsed = InAppMessageParser.parseRequiredFields(from: message, dateParser: dateParser)
+
+        XCTAssertEqual(parsed?.id, Int64.max)
+    }
+
+    // MARK: - content (crash regression)
+
+    func testRejectsMissingContent() {
+        var message = validMessage()
+        message.removeValue(forKey: "content")
+
+        XCTAssertNil(InAppMessageParser.parseRequiredFields(from: message, dateParser: dateParser))
+    }
+
+    func testRejectsNullContent() {
+        let message = validMessage(overrides: ["content": NSNull()])
+
+        XCTAssertNil(InAppMessageParser.parseRequiredFields(from: message, dateParser: dateParser))
+    }
+
+    func testRejectsStringContent() {
+        let message = validMessage(overrides: ["content": "<p>not a dictionary</p>"])
+
+        XCTAssertNil(InAppMessageParser.parseRequiredFields(from: message, dateParser: dateParser))
+    }
+
+    func testRejectsArrayContent() {
+        let message = validMessage(overrides: ["content": ["a", "b"]])
+
+        XCTAssertNil(InAppMessageParser.parseRequiredFields(from: message, dateParser: dateParser))
+    }
+
+    // MARK: - id
+
+    func testRejectsMissingId() {
+        var message = validMessage()
+        message.removeValue(forKey: "id")
+
+        XCTAssertNil(InAppMessageParser.parseRequiredFields(from: message, dateParser: dateParser))
+    }
+
+    func testRejectsStringId() {
+        let message = validMessage(overrides: ["id": "42"])
+
+        XCTAssertNil(InAppMessageParser.parseRequiredFields(from: message, dateParser: dateParser))
+    }
+
+    // MARK: - updatedAt / presentedWhen
+
+    func testRejectsMissingUpdatedAt() {
+        var message = validMessage()
+        message.removeValue(forKey: "updatedAt")
+
+        XCTAssertNil(InAppMessageParser.parseRequiredFields(from: message, dateParser: dateParser))
+    }
+
+    func testRejectsInvalidUpdatedAt() {
+        let message = validMessage(overrides: ["updatedAt": "not-a-date"])
+
+        XCTAssertNil(InAppMessageParser.parseRequiredFields(from: message, dateParser: dateParser))
+    }
+
+    func testRejectsMissingPresentedWhen() {
+        var message = validMessage()
+        message.removeValue(forKey: "presentedWhen")
+
+        XCTAssertNil(InAppMessageParser.parseRequiredFields(from: message, dateParser: dateParser))
+    }
+}


### PR DESCRIPTION
### Description of Changes

The SDK force-cast remote message `content` to `NSDictionary`; when `content` was missing, null, a string, an array, or another unsupported type,

**Changes:**
- Parse required in-app message fields with Overlay-style safe casting (`InAppMessageParser`) instead of force-casts
- Skip malformed messages and only track delivery for successfully parsed payloads
- Add unit tests covering valid payloads and the crash-triggering `content` variants
- Bump version to **6.8.1** and update changelog

### Breaking Changes

-   None

### Release Checklist

### Prepare:

- [x] Detail any breaking changes. Breaking changes require a new major version number
- [ ] Check `pod lib lint` passes
- [ ] Update any relevant sections of the repository wiki pages on a branch

### Bump versions in:

- [x] `OptimoveCore.podspec`
- [x] `OptimoveNotificationServiceExtension.podspec`
- [x] `OptimoveSDK.podspec`
- [x] `OptimoveCore/Sources/Classes/Constants/SDKVersion.swift`
- [x] `README.md` *(no hardcoded version to update)*
- [x] `CHANGELOG.md`
- [ ] Update major version numbers in wiki (basic integration + push guides) *(N/A — patch release)*

### Integration tests

*T&T Only*

- [ ] Init SDK with only T&T credentials
- [ ] Associate customer
- [ ] Associate email
- [ ] Track events

*Mobile Only*

- [ ] Init SDK with all credentials
- [ ] Track events
- [ ] Associate customer (verify both backends)
- [ ] Register for push
- [ ] Opt-in for In-App
- [ ] Send test push
- [ ] Send test In-App
- [ ] Receive / trigger deep link handler (In-App/Push)
- [ ] Receive / trigger the content extension, render image and action buttons for push
- [ ] Verify push opened handler

*Deferred Deep Links*

- [ ] With app installed, trigger deep link handler
- [ ] With app uninstalled, follow deep link, install test bundle, verify deep link read from Clipboard, trigger deep link handler

*Combined*

- [ ] Track event for T&T, verify push received
- [ ] Trigger scheduled campaign, verify push received
- [ ] Trigger scheduled campaign, verify In-App received

### Release:

- [ ] Squash and merge to master
- [ ] Delete branch once merged
- [ ] Create tag from master matching chosen version
- [ ] Run `pod trunk push` to publish to CocoaPods

### Post Release:

- [ ] Push wiki pages to master